### PR TITLE
fix(app-builder): use cross-spawn for pnpm on Windows

### DIFF
--- a/sdk/app-builder/package.json
+++ b/sdk/app-builder/package.json
@@ -15,6 +15,7 @@
     "@phosphor-icons/react": "^2.1.10",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cross-spawn": "^7.0.6",
     "next": "16.2.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",
@@ -25,6 +26,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/cross-spawn": "^6.0.6",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/sdk/app-builder/pnpm-lock.yaml
+++ b/sdk/app-builder/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cross-spawn:
+        specifier: ^7.0.6
+        version: 7.0.6
       next:
         specifier: 16.2.4
         version: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -48,6 +51,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.4
+      '@types/cross-spawn':
+        specifier: ^6.0.6
+        version: 6.0.6
       '@types/node':
         specifier: ^20
         version: 20.19.39
@@ -809,6 +815,9 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/cross-spawn@6.0.6':
+    resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
@@ -4355,6 +4364,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/cross-spawn@6.0.6':
+    dependencies:
+      '@types/node': 20.19.39
 
   '@types/debug@4.1.13':
     dependencies:

--- a/sdk/app-builder/src/lib/app-builder/server.ts
+++ b/sdk/app-builder/src/lib/app-builder/server.ts
@@ -1,4 +1,5 @@
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process"
+import spawn from "cross-spawn"
+import type { ChildProcess } from "node:child_process"
 import { randomUUID } from "node:crypto"
 import { promises as fs } from "node:fs"
 import net from "node:net"
@@ -27,7 +28,7 @@ type BuilderSession = {
   port: number
   logs: string[]
   ready: Promise<void>
-  devProcess?: ChildProcessWithoutNullStreams
+  devProcess?: ChildProcess
   agent?: SDKAgent
   setupError?: string
 }
@@ -936,7 +937,7 @@ function runCommand(
 }
 
 function pipeProcessLogs(
-  child: ChildProcessWithoutNullStreams,
+  child: ChildProcess,
   session: BuilderSession,
   label: string
 ) {
@@ -945,8 +946,8 @@ function pipeProcessLogs(
     session.logs.splice(0, Math.max(0, session.logs.length - 200))
   }
 
-  child.stdout.on("data", append)
-  child.stderr.on("data", append)
+  child.stdout?.on("data", append)
+  child.stderr?.on("data", append)
 }
 
 function waitForPort(port: number, timeoutMs = 30_000): Promise<void> {


### PR DESCRIPTION
## Problem

On Windows, spawning `pnpm` with Node's native `child_process.spawn(`pnpm`, ...)` could fail with `spawn pnpm ENOENT` when the app-builder server runs `pnpm install` and `pnpm exec vite …`.

## Solution

- Use `cross-spawn` for those subprocess calls so Windows resolves `pnpm.cmd`/shims correctly.
- Add `@types/cross-spawn` as a devDependency and relax `devProcess` typing to match `cross-spawn`'s returned `ChildProcess`; use optional chaining when piping stdout/stderr.

## Testing

- `pnpm build` succeeds in `sdk/app-builder`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how `pnpm install` and the Vite dev server are spawned and how their streams are handled, which could affect session setup/startup across platforms.
> 
> **Overview**
> Fixes Windows failures when starting app-builder sessions by replacing Node’s `child_process.spawn` usage with `cross-spawn` for `pnpm` commands.
> 
> Updates process typing (`ChildProcess`) and log piping to tolerate missing `stdout`/`stderr` streams via optional chaining, and adds `cross-spawn` plus `@types/cross-spawn` to dependencies/lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c25b941cd017f1841d003f0cab661cc7157b638c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->