### PR TITLE
fix(app-builder): fix SSR hydration mismatch from localStorage

### DIFF
--- a/sdk/app-builder/src/components/app-builder.tsx
+++ b/sdk/app-builder/src/components/app-builder.tsx
@@ -4,6 +4,7 @@ import {
   FormEvent,
   type MouseEvent as ReactMouseEvent,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -220,26 +221,20 @@ const fallbackModels: ModelCatalogItem[] = [
 const fallbackModelSelection = encodeModelSelection({ id: fallbackModels[0].id })
 
 export function AppBuilder() {
-  const [initialAppState] = useState(readPersistedAppState)
-  const [conversations, setConversations] = useState(
-    initialAppState.conversations
-  )
+  const [bootstrap] = useState(createInitialAppState)
+  const [conversations, setConversations] = useState(bootstrap.conversations)
   const [activeConversationId, setActiveConversationId] = useState(
-    initialAppState.activeConversationId
+    bootstrap.activeConversationId
   )
   const [apiKey, setApiKey] = useState("")
   const [hasSavedApiKey, setHasSavedApiKey] = useState(false)
   const [runtimeByConversationId, setRuntimeByConversationId] = useState<
     Record<string, ConversationRuntimeState>
-  >(() => {
-    return {
-      [initialAppState.activeConversationId]: createRuntimeState(),
-    }
-  })
+  >(() => ({
+    [bootstrap.activeConversationId]: createRuntimeState(),
+  }))
   const [isProjectSidebarOpen, setIsProjectSidebarOpen] = useState(true)
-  const [isOnboardingOpen, setIsOnboardingOpen] = useState(
-    () => !isCursorApiKey(getSavedCursorApiKey() ?? "")
-  )
+  const [isOnboardingOpen, setIsOnboardingOpen] = useState(true)
   const [isApiKeySettingsOpen, setIsApiKeySettingsOpen] = useState(false)
   const [isApiKeyClearConfirming, setIsApiKeyClearConfirming] = useState(false)
   const [titleGenerationConversationIds, setTitleGenerationConversationIds] =
@@ -277,6 +272,24 @@ export function AppBuilder() {
     () => [...conversations].sort((a, b) => b.updatedAt - a.updatedAt),
     [conversations]
   )
+
+  useLayoutEffect(() => {
+    const persisted = readPersistedAppStateFromStorage()
+    setConversations(persisted.conversations)
+    setActiveConversationId(persisted.activeConversationId)
+    setRuntimeByConversationId(
+      Object.fromEntries(
+        persisted.conversations.map((conversation) => [
+          conversation.id,
+          createRuntimeState(),
+        ])
+      )
+    )
+    const savedKey = getSavedCursorApiKey()
+    if (savedKey && isCursorApiKey(savedKey)) {
+      setIsOnboardingOpen(false)
+    }
+  }, [])
 
   useEffect(() => {
     conversationsRef.current = conversations
@@ -4027,11 +4040,8 @@ function getProjectNameMessages(conversation: Conversation): ProjectNameMessage[
     : conversationContext
 }
 
-function readPersistedAppState(): PersistedAppState {
-  if (typeof window === "undefined") {
-    return createInitialAppState()
-  }
-
+/** Client-only: restores chats after SSR hydration so markup matches server on first paint. */
+function readPersistedAppStateFromStorage(): PersistedAppState {
   try {
     const raw = window.localStorage.getItem(SAVED_CHAT_STATE)
     if (!raw) {


### PR DESCRIPTION
## Summary
Fixes React hydration errors in the app builder when saved chat state exists in `localStorage`.

Previously, the server rendered the default empty state (`createInitialAppState()`) while the client immediately read persisted conversations on the first render, so titles, session-derived layout (`main` classes), and onboarding could disagree between SSR and the client.

## Changes
- Seed initial state only from `createInitialAppState()` so the first server and client paints match.
- Restore persisted conversations, active conversation, runtime map, and onboarding (when a valid Cursor API key is saved) in `useLayoutEffect` after hydration.
- Rename the loader to `readPersistedAppStateFromStorage()` (client-only).

## Testing
- Open app builder with existing `localStorage` data; confirm no hydration warning overlay.
- Fresh profile / cleared storage still shows default "Project 1" flow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to client-side state initialization timing to prevent SSR hydration warnings; main risk is minor UI flicker/regressions in restore/onboarding state.
> 
> **Overview**
> Fixes React hydration mismatches in `AppBuilder` by **bootstrapping initial UI state purely from `createInitialAppState()`** (instead of reading `localStorage` during initial render).
> 
> After hydration, a `useLayoutEffect` now restores persisted conversations/active conversation and rebuilds `runtimeByConversationId`, and onboarding is closed when a valid saved Cursor API key is present. The persisted-state loader is renamed/clarified as client-only via `readPersistedAppStateFromStorage()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2298e75b474359a1ad2a689fb0a04cf6ef8f73e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->