### PR TITLE
agent-kanban: validate artifact media Content-Type before forwarding

### DIFF
--- a/sdk/agent-kanban/src/lib/agents/server.ts
+++ b/sdk/agent-kanban/src/lib/agents/server.ts
@@ -443,9 +443,10 @@ export async function readArtifactContent(
 
       return {
         bytes: new Uint8Array(await artifactResponse.arrayBuffer()),
-        contentType:
-          artifactResponse.headers.get("content-type") ??
-          contentTypeForArtifactPath(artifactPath),
+        contentType: sanitizeArtifactContentType(
+          artifactResponse.headers.get("content-type"),
+          artifactPath
+        ),
       }
     }
 
@@ -466,7 +467,7 @@ export async function readArtifactContent(
     if (response instanceof Blob) {
       return {
         bytes: new Uint8Array(await response.arrayBuffer()),
-        contentType: response.type || contentTypeForArtifactPath(artifactPath),
+        contentType: sanitizeArtifactContentType(response.type, artifactPath),
       }
     }
   } finally {
@@ -918,6 +919,30 @@ function labelFromRepositoryString(value: string) {
     .replace(/\.git$/, "")
 }
 
+const SAFE_ARTIFACT_CONTENT_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "image/avif",
+  "video/mp4",
+  "video/webm",
+  "video/quicktime",
+])
+
+function sanitizeArtifactContentType(
+  raw: string | null | undefined,
+  artifactPath: string
+): string {
+  if (raw) {
+    const mimeType = raw.split(";")[0].trim().toLowerCase()
+    if (SAFE_ARTIFACT_CONTENT_TYPES.has(mimeType)) {
+      return mimeType
+    }
+  }
+  return contentTypeForArtifactPath(artifactPath)
+}
+
 function getArtifactPreviewKind(
   artifactPath: string,
   contentType?: string
@@ -962,9 +987,6 @@ function contentTypeForArtifactPath(artifactPath: string) {
   }
   if (normalized.endsWith(".gif")) {
     return "image/gif"
-  }
-  if (normalized.endsWith(".svg")) {
-    return "image/svg+xml"
   }
   return "application/octet-stream"
 }


### PR DESCRIPTION
The artifact media proxy in `sdk/agent-kanban` just pipes whatever `Content-Type` the upstream CDN sends straight to the browser. Normally fine, but `ArtifactTile` wraps every preview in `<a href={mediaUrl} target="_blank">` — so if a CDN serves an artifact with `Content-Type: image/svg+xml`, clicking the thumbnail opens it as a top-level SVG document on the app's own origin, where `<script>` tags run freely.

SVG-as-image (inside `<img>`) is sandboxed. SVG-as-document is not. That distinction is what makes this worth closing.

**What the fix does:**

Adds a small allowlist of image/video MIME types that are actually safe to reflect. Anything not on the list falls back to `contentTypeForArtifactPath()` extension sniffing — and `image/svg+xml` is intentionally left out of both so SVGs land as `application/octet-stream` instead of executing. Both the URL-fetch path and the Blob path in `readArtifactContent` go through the same sanitizer.

No behaviour change for normal PNG/JPEG/GIF/WebP/AVIF/MP4/WebM artifacts.