### PR TITLE
Fix Windows process spawning for app builder pnpm commands.

### DIFF
--- a/sdk/app-builder/src/lib/app-builder/server.ts
+++ b/sdk/app-builder/src/lib/app-builder/server.ts
@@ -130,6 +130,8 @@ const appBuilderRoot = path.join(os.homedir(), ".app-builder")
 const workspaceRoot = path.join(appBuilderRoot, "sessions")
 const settingsPath = path.join(appBuilderRoot, "settings.json")
 const DEFAULT_PROJECT_NAME_TIMEOUT_MS = 15_000
+const packageManagerCommand = "pnpm"
+const useShellForPnpm = process.platform === "win32"
 const APP_BUILDER_INSTRUCTIONS = [
   "You are building a local Vite React TypeScript application for a live preview product.",
   "Edit files directly in the current workspace. The dev server is already running and hot reloads when files change.",
@@ -855,7 +857,7 @@ function normalizeModelToken(value: string) {
 async function prepareSession(session: BuilderSession) {
   await fs.mkdir(session.projectPath, { recursive: true })
   await writeGeneratedApp(session.projectPath)
-  await runCommand("pnpm", ["install"], session)
+  await runCommand(packageManagerCommand, ["install"], session)
   await startDevServer(session)
 }
 
@@ -875,7 +877,7 @@ async function startDevServer(session: BuilderSession) {
   }
 
   const child = spawn(
-    "pnpm",
+    packageManagerCommand,
     [
       "exec",
       "vite",
@@ -888,7 +890,7 @@ async function startDevServer(session: BuilderSession) {
     {
       cwd: session.projectPath,
       env: { ...process.env, BROWSER: "none" },
-      shell: false,
+      shell: useShellForPnpm,
     }
   )
 
@@ -912,7 +914,7 @@ function runCommand(
     const child = spawn(command, args, {
       cwd: session.projectPath,
       env: { ...process.env, CI: "1" },
-      shell: false,
+      shell: useShellForPnpm,
     })
 
     pipeProcessLogs(child, session, command)


### PR DESCRIPTION
Use a Windows-safe spawn configuration when invoking pnpm install and pnpm exec vite so session startup no longer fails with ENOENT/EINVAL on Windows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to process spawning options; behavior is unchanged on non-Windows platforms and only affects session setup/dev server launch.
> 
> **Overview**
> Fixes Windows session startup failures by adjusting how the app builder spawns `pnpm` processes.
> 
> `prepareSession`, `runCommand`, and `startDevServer` now use a shared `packageManagerCommand` and enable `spawn(..., { shell: true })` only on Windows, avoiding `ENOENT/EINVAL` errors when running `pnpm install` and `pnpm exec vite`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d72e9a6b2d7c85553f1541f9b3bd30f220223a66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->