### PR TITLE
fix(app-builder): correct typescript dependency classification in template

### DIFF
--- a/sdk/app-builder/src/lib/app-builder/template.ts
+++ b/sdk/app-builder/src/lib/app-builder/template.ts
@@ -19,7 +19,6 @@ export const generatedAppFiles: TemplateFile[] = [
         },
         dependencies: {
           "@vitejs/plugin-react": "latest",
-          typescript: "latest",
           vite: "latest",
           react: "latest",
           "react-dom": "latest",
@@ -27,6 +26,7 @@ export const generatedAppFiles: TemplateFile[] = [
         devDependencies: {
           "@types/react": "latest",
           "@types/react-dom": "latest",
+          typescript: "latest",
         },
       },
       null,


### PR DESCRIPTION
Fix incorrect dependency classification in generated template.

## Changes
Move `typescript` from `dependencies` to `devDependencies` in the generated template.

## Why need?
TypeScript is a build-time tool, not a runtime dependency. Keeping it in `dependencies` unnecessarily increases install size and goes against Node.js best practices.

## Impact
Cleaner generated projects
 Smaller install footprint
 Aligns with standard Node.js practices

## Risk
None  only affects new scaffolded projects

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts dependency classification in the generated app template and does not affect runtime code paths; impact is limited to newly scaffolded projects.
> 
> **Overview**
> Updates the app-builder template `package.json` generation to list `typescript` under `devDependencies` instead of `dependencies`, keeping runtime installs smaller and aligning the scaffolded project’s dependency layout with typical Node/TS conventions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33301002d417a804e8d6d6c87b8f7e3b4118ccd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->