### PR TITLE
fix(agent-kanban): apply onlyBuiltDependencies via pnpm-workspace.yaml

### DIFF
--- a/sdk/agent-kanban/package.json
+++ b/sdk/agent-kanban/package.json
@@ -32,8 +32,5 @@
     "eslint-config-next": "16.2.4",
     "tailwindcss": "^4",
     "typescript": "^5"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": ["sqlite3"]
   }
 }

--- a/sdk/agent-kanban/pnpm-workspace.yaml
+++ b/sdk/agent-kanban/pnpm-workspace.yaml
@@ -1,2 +1,9 @@
 packages:
   - "."
+
+onlyBuiltDependencies:
+  - esbuild
+  - msw
+  - sharp
+  - sqlite3
+  - unrs-resolver


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The **Cursor Cookbook** `sdk/agent-kanban` package was using `pnpm.onlyBuiltDependencies` in `package.json` with only `sqlite3`. Under **pnpm 10**, that allowlist did not take effect for the workspace root the same way as in `sdk/app-builder`, so install scripts for **sharp**, **msw**, **unrs-resolver**, and **esbuild** were skipped and users could see warnings or broken Next.js/image behavior.

## Changes

- Move the built-dependencies allowlist to `pnpm-workspace.yaml` (same pattern as `sdk/app-builder`) so pnpm applies it when installing from that directory.
- Remove the redundant `pnpm` block from `package.json`.

This matches how other examples in the repo configure trusted install scripts and makes a clean `pnpm install` in `sdk/agent-kanban` run the expected native/postinstall steps.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b5057e5-8d56-4254-bed1-44c6c4028c94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b5057e5-8d56-4254-bed1-44c6c4028c94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

