### PR TITLE
docs: add Chinese (Simplified) translations for all READMEs

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,31 @@
+# Cursor Cookbook
+
+本仓库包含使用 Cursor 构建应用的小型示例集合。
+
+## Cursor SDK
+
+Cursor SDK 是 TypeScript API，让你能以自己的应用、脚本和工作流运行 Cursor 的编码 Agent。它支持跨本地工作区和云端运行时的同一 Agent，以流式方式返回 Agent 事件，并允许你通过代码管理提示词、模型选择、取消操作、制品和对话状态。
+
+要运行 SDK 示例，请先从 [Cursor 集成面板](https://cursor.com/dashboard/integrations) 创建一个 Cursor API Key，然后将其设置为环境变量 `CURSOR_API_KEY`。
+
+### [快速开始](sdk/quickstart)
+
+一个极简的 Node.js 示例，创建一个本地 Agent，发送一条提示，并以流式方式获取响应。
+
+### [原型构建工具](sdk/app-builder)
+
+一个 Web 应用，用于快速启动 Agent 来搭建新项目并在沙盒云环境中迭代创意。
+
+### [看板面板](sdk/agent-kanban)
+
+一个看板面板，用于查看 Cursor Cloud Agents，按状态或仓库分组，预览制品，并基于仓库和提示创建新的云端 Agent。
+
+### [编码 Agent CLI](sdk/coding-agent-cli)
+
+一个极简的命令行界面，让你从终端启动 Cursor Agent。
+
+### [DAG 任务编排器](sdk/dag-task-runner)
+
+将任务拆解为 JSON DAG（有向无环图），在本地子 Agent 之间分发执行，并将实时状态流式输出到 Cursor Canvas，每次状态变更时 Canvas 会自动热重载。既可以作为可运行的示例使用，也可以作为可复制的 Cursor Skill 使用，位于 [`.cursor/skills/dag-task-runner`](.cursor/skills/dag-task-runner)。
+
+了解更多请参阅 [Cursor SDK TypeScript 文档](https://cursor.com/docs/api/sdk/typescript)。

--- a/sdk/agent-kanban/README.zh-CN.md
+++ b/sdk/agent-kanban/README.zh-CN.md
@@ -1,0 +1,24 @@
+# Cursor SDK Agent 看板
+
+一个 Linear 风格的 Cursor Cloud Agents 面板。它使用 Cursor SDK 列出云端 Agent，将其分组为看板列，在卡片上预览制品，并支持从仓库和提示词创建新的云端 Agent。
+
+本示例演示了：
+
+- API Key 接入流程（加载云端 Agent 数据前必需）
+- 云端 Agent 列表展示，支持按状态、仓库、分支或创建日期分组
+- Agent 卡片，包含状态、仓库/分支元数据、最新活动、PR 链接和制品预览
+- 基于 `Agent.create({ cloud: { repos } })` 的创建 Agent 流程
+- 通过本地 API 路由代理的身份验证制品媒体预览
+
+## 开始使用
+
+```bash
+pnpm install
+pnpm dev
+```
+
+打开本地 Next.js URL，然后从 [Cursor 集成面板](https://cursor.com/dashboard/integrations) 输入 Cursor API Key 完成接入。如果勾选了"记住此 Key"，API Key 将存储在 `~/.agent-kanban/settings.json`；否则仅保存在内存会话中。
+
+## 说明
+
+仓库列表受 Cloud Agents API 的速率限制，并在内存中进行短期缓存。制品预览通过经过身份验证的本地 API 路由获取，如果预览停止加载请刷新面板。

--- a/sdk/app-builder/README.zh-CN.md
+++ b/sdk/app-builder/README.zh-CN.md
@@ -1,0 +1,28 @@
+# Cursor SDK App Builder
+
+这是一个展示 Cursor SDK 构建能力的小型示例。它启动一个本地 Cursor Agent 会话，搭建一个支持热重载的 React 预览应用，并让你通过聊天界面在该应用上迭代。
+
+目标是演示一个完整的端到端应用构建循环：
+
+- 在本地收集 Cursor API Key
+- 创建隔离的预览工作区
+- 流式输出 Agent 响应和工具活动
+- 在 iframe 中预览生成的 UI
+- 管理多个应用构建对话
+
+## 开始使用
+
+安装依赖并启动 Next.js 宿主应用：
+
+```bash
+pnpm install
+pnpm dev
+```
+
+打开 [http://localhost:3000](http://localhost:3000)。
+
+首次启动时，粘贴你的 Cursor API Key。应用会将其存储在本地 `~/.app-builder/settings.json` 中，并用于创建本地 Agent 会话。
+
+## 说明
+
+此应用旨在作为本地 Cursor SDK 演示。请不要在没有添加身份验证、用户独立存储以及更强的密钥保护措施的情况下，将其部署为公开共享服务。

--- a/sdk/coding-agent-cli/README.zh-CN.md
+++ b/sdk/coding-agent-cli/README.zh-CN.md
@@ -1,0 +1,35 @@
+# 编码 Agent CLI
+
+一个小型示例 CLI，在工作区中运行 Cursor SDK Agent。单次提示默认使用本地运行时，交互式 TUI 可在本地和云端执行之间切换。
+
+## 开始使用
+
+需要 Bun 1.3 或更高版本。此 CLI 仅支持 Bun，因为 OpenTUI 的原生渲染器通过 `bun:ffi` 暴露。
+
+安装依赖：
+
+```bash
+pnpm install
+```
+
+设置 API Key：
+
+```bash
+export CURSOR_API_KEY="crsr_..."
+```
+
+在当前目录下执行单次任务：
+
+```bash
+bun run dev -- "解释一下这个项目的结构"
+```
+
+不加提示词启动 TUI：
+
+```bash
+bun run dev
+```
+
+## 说明
+
+在 TUI 中，输入 `/` 打开命令菜单。你可以在其中切换本地或云端执行、选择模型、重置会话或退出。

--- a/sdk/dag-task-runner/README.zh-CN.md
+++ b/sdk/dag-task-runner/README.zh-CN.md
@@ -1,0 +1,203 @@
+# DAG 任务编排器
+
+将任务拆解为 JSON DAG（有向无环图），以拓扑顺序将每个节点作为 Cursor SDK 本地子 Agent 运行，并将实时状态流式输出到 [Cursor Canvas](https://cursor.com/docs/canvases)，每次状态变更时 Canvas 自动热重载。
+
+![实时 DAG Canvas 预览](docs/demo_vid_dag.gif)
+
+> 以上为 Canvas 的运行录制。每次编排器将新状态写入磁盘时，IDE 都会重新渲染 Canvas，因此你可以实时看到任务依次经过 `PENDING → RUNNING → FINISHED/ERROR` 状态。
+
+## 功能说明
+
+- **编写 DAG**：以带有显式 `depends_on` 依赖边和每任务 `complexity`（HIGH / MED / LOW）的子任务定义 DAG，编排器通过可配置的默认值将其映射到 Cursor 模型。
+- **拓扑排序**：将 DAG 按层级排序（Kahn 算法），并通过 `Promise.all` 并发执行同层级任务，独立任务自动并行执行。
+- **上游输出拼接**：将上游输出自动注入到子任务的提示词中——每个子任务会自动获取每个父任务结果的 2,000 字符摘要，无需手动描述。
+- **实时流式输出**：写入 `.canvas.tsx` 文件。每次写入时 Cursor 重新编译 Canvas，因此你在每个任务卡片上可以看到逐 token 的输出内容。
+- **安全容错**：超时将任务标记为 `ERROR` 而非挂起，下游依赖自动跳过，SIGINT/SIGTERM 会取消正在执行的子 Agent 并在退出前完成 Canvas 写入。
+
+## 开始使用
+
+需要 Node.js 22 或更高版本。
+
+安装依赖：
+
+```bash
+pnpm install
+```
+
+设置 Cursor API Key：
+
+```bash
+export CURSOR_API_KEY="crsr_..."
+```
+
+渲染初始 Canvas（无需 API Key），以便在运行前打开它：
+
+```bash
+pnpm init-canvas
+open .canvas/dag-example.canvas.tsx
+```
+
+端到端运行示例 DAG：
+
+```bash
+pnpm example
+```
+
+该示例构建了一个微型单文件 CLI 待办事项应用。任务默认在 `process.cwd()` 下运行，如果不想在 cookbook 目录中生成文件，请使用临时目录：
+
+```bash
+mkdir -p /tmp/dag-demo && cd /tmp/dag-demo
+CURSOR_API_KEY="crsr_..." \
+  pnpm --dir ~/Code/cookbook/sdk/dag-task-runner \
+  dev -- --dag examples/example_dag.json --canvas-path "$PWD/dag-example.canvas.tsx" --cwd "$PWD"
+```
+
+观察 [`dag-example.canvas.tsx`](./examples/example_dag.json) 随每个层级的执行实时刷新：
+
+```
+[dag-runner] DAG "构建一个微型 CLI 待办应用" — 6 个任务跨越 4 层
+[dag-runner] rank 1/4: research-stack, research-cli-conventions
+[dag-runner] rank 2/4: design
+[dag-runner] rank 3/4: implement
+[dag-runner] rank 4/4: tests, docs
+[dag-runner] 完成 — 6/6 成功，耗时 1 分 47 秒
+```
+
+## DAG 结构
+
+```json
+{
+  "title": "构建一个微型 CLI 待办应用",
+  "models": {
+    "HIGH": "gpt-5.3-codex",
+    "MED": "composer-2",
+    "LOW": "auto-low"
+  },
+  "tasks": [
+    {
+      "id": "research-stack",
+      "depends_on": [],
+      "complexity": "LOW",
+      "subtask_prompt": "勾勒最小可行设计方案……"
+    }
+  ]
+}
+```
+
+| 字段 | 必需 | 说明 |
+|------|------|------|
+| `id` | 是 | 唯一的短横线命名标识符，供其他任务的 `depends_on` 引用 |
+| `depends_on` | 是 | `id` 数组。第一层任务为空数组。检测到循环引用时拒绝解析 |
+| `complexity` | 是 | `HIGH`、`MED` 或 `LOW`。通过下方的模型映射表解析 |
+| `subtask_prompt` | 是 | 自包含的提示词——编排器会自动在开头拼接上游输出摘要 |
+| `models` | 否 | 顶层部分复杂度 → 模型覆盖映射 |
+
+参见 [`examples/example_dag.json`](./examples/example_dag.json) 获取完整示例。
+
+## 复杂度模型映射
+
+默认情况下，复杂度映射关系如下：
+
+| 复杂度 | 默认模型 |
+|--------|----------|
+| `HIGH` | `gpt-5.3-codex` |
+| `MED` | `composer-2` |
+| `LOW` | `auto-low` |
+
+你可以在 DAG 文件中以顶层 `models` 对象覆盖任意子集，或将可复用的配置保存在 JSON 文件中：
+
+```json
+{
+  "HIGH": "gpt-5.3-codex",
+  "MED": "composer-2",
+  "LOW": "auto-low"
+}
+```
+
+然后运行：
+
+```bash
+pnpm dev -- --dag examples/example_dag.json --models-file ./models.fast.json --canvas-path "$PWD/.canvas/dag-example.canvas.tsx"
+```
+
+优先级顺序为：默认值 < DAG `models` < `--models-file`。Cursor SDK 的模型目录因账户而异；官方 SDK 文档建议使用 `Cursor.models.list()` 确认有效的模型 ID。
+
+## CLI 参数
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `--dag` | 必填 | DAG JSON 文件路径 |
+| `--canvas-path` | 自动拼接 | Canvas 文件的完整绝对路径。推荐用于父进程管理流程 |
+| `--canvas` | — | Canvas 文件名主干（不含 `.canvas.tsx`）。仅在未指定 `--canvas-path` 时使用 |
+| `--canvases-dir` | 按工作区 | 覆盖 Canvas 输出目录。仅与 `--canvas` 配合使用 |
+| `--cwd` | `process.cwd()` | 每个子 Agent 的工作目录 |
+| `--models-file` | — | 包含部分复杂度 → 模型覆盖映射的 JSON 文件 |
+| `--init-only` | `false` | 写入初始全 `PENDING` 状态的 Canvas 后退出。无需 `CURSOR_API_KEY` |
+| `--debounce` | `200` ms | Canvas 写入防抖间隔 |
+| `--task-timeout-ms` | `1200000`（20 分钟） | 超过此时长将任务标记为 `ERROR` |
+| `--stream-publish-ms` | `500` ms | 实时 Canvas 流式写入限流间隔 |
+| `--stream-idle-timeout-ms` | `300000`（5 分钟） | 在此窗口内未收到流事件则将任务标记为 `ERROR` |
+
+## 作为 Cursor Skill 使用
+
+本仓库附带了一个立即可用的 Skill，位于 [`../../.cursor/skills/dag-task-runner`](../../.cursor/skills/dag-task-runner)。将其复制到另一个项目或您的个人 Skill 文件夹：
+
+```bash
+# 为另一个项目添加项目级 Skill
+mkdir -p /path/to/project/.cursor/skills
+cp -R .cursor/skills/dag-task-runner /path/to/project/.cursor/skills/
+
+# 添加跨工作区可用的个人 Skill
+mkdir -p ~/.cursor/skills
+cp -R .cursor/skills/dag-task-runner ~/.cursor/skills/
+```
+
+复制的 Skill 包含 `SKILL.md`、`examples/` 和 `scripts/` 运行时目录。不包含 `node_modules`；Skill 的说明会在首次使用时自动在 `scripts/` 中安装依赖。
+
+Skill 按以下顺序自动检测编排器路径：
+
+1. `DAG_RUNNER_DIR` 环境变量（如已设置）
+2. `<当前工作目录>/.cursor/skills/dag-task-runner/scripts`
+3. `<Git 根目录>/.cursor/skills/dag-task-runner/scripts`
+4. `~/.cursor/skills/dag-task-runner/scripts`
+
+## 同步可复制制品
+
+保持 [`../../.cursor/skills/dag-task-runner`](../../.cursor/skills/dag-task-runner) 与 SDK 源码同步：
+
+```bash
+./scripts/sync-copyable-skill.sh
+```
+
+修改 `src/`、`skill/SKILL.md`、`examples/`、`package.json` 或 `tsconfig.json` 后运行此命令。
+
+## 项目结构
+
+```
+sdk/dag-task-runner/
+├── README.md                     # 英文原版
+├── README.zh-CN.md               # 中文翻译
+├── package.json                  # @cursor/sdk ^1.0.9, tsx, typescript
+├── tsconfig.json
+├── pnpm-workspace.yaml
+├── src/
+│   ├── run_dag.ts                # 入口点 + 每任务生命周期
+│   ├── dag.ts                    # 解析、校验、循环检测、拓扑排序
+│   └── canvas_writer.ts          # 防抖 .canvas.tsx 渲染器
+├── examples/
+│   └── example_dag.json          # 6任务"微型 CLI 待办应用"示例 DAG
+├── docs/
+│   ├── dag-canvas-preview.png    # Canvas 截图
+│   └── demo_vid_dag.gif          # 本 README 中使用的动画 Canvas 演示
+├── skill/
+│   └── SKILL.md                  # 可复制 Skill 说明的来源
+└── scripts/
+    └── sync-copyable-skill.sh    # 重新生成 ../../.cursor/skills/dag-task-runner/
+```
+
+## 说明
+
+- 编排器使用本地 Cursor SDK 运行时——每个子 Agent 在 `--cwd` 目录下运行（默认为调用编排器的位置）。
+- 同一层级的兄弟任务并行执行；请勿让它们写入相同文件。
+- 每任务流式文本限制为 4,000 字符，传递给子任务的上游上下文限制为每个父任务 2,000 字符，以保持 Canvas 文件大小适中。
+- 如需更深入的 API 介绍，请参见 [Cursor SDK TypeScript 文档](https://cursor.com/docs/api/sdk/typescript) 和同级目录下的[快速开始](../quickstart)示例。

--- a/sdk/quickstart/README.zh-CN.md
+++ b/sdk/quickstart/README.zh-CN.md
@@ -1,0 +1,36 @@
+# Cursor SDK 快速开始
+
+一个极简的本地 Cursor SDK 示例：创建一个 Agent，发送一条硬编码的提示词，将助手回复流式输出到标准输出，并等待运行完成。
+
+## 开始使用
+
+需要 Node.js 22 或更高版本。
+
+安装依赖：
+
+```bash
+pnpm install
+```
+
+设置 Cursor API Key：
+
+```bash
+export CURSOR_API_KEY="crsr_..."
+```
+
+运行快速开始：
+
+```bash
+pnpm dev
+```
+
+编译并运行：
+
+```bash
+pnpm build
+pnpm start
+```
+
+## 说明
+
+如需更完整的终端应用（支持参数、云模式、模型选择和交互式 TUI），请参见[编码 Agent CLI](../coding-agent-cli)。


### PR DESCRIPTION
## 中文翻译贡献

为所有 README 添加了简体中文翻译（README.zh-CN.md），共 6 篇：

| 文件 | 说明 |
|------|------|
| README.zh-CN.md | 根目录导航页 |
| sdk/quickstart/README.zh-CN.md | 快速开始 |
| sdk/app-builder/README.zh-CN.md | 原型构建工具 |
| sdk/agent-kanban/README.zh-CN.md | Agent 看板 |
| sdk/coding-agent-cli/README.zh-CN.md | 编码 Agent CLI |
| sdk/dag-task-runner/README.zh-CN.md | DAG 任务编排器（含 CLI 参数表和项目结构图） |

所有英文原文保持不变。中文翻译文件以 README.zh-CN.md 命名，与原文并存。

欢迎 review 和修改建议！

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds new `README.zh-CN.md` files; no runtime behavior or APIs are modified.
> 
> **Overview**
> Adds Simplified Chinese (`zh-CN`) translations for the root README and five SDK example READMEs (quickstart, app builder, agent kanban, coding-agent CLI, and DAG task runner), keeping the English originals unchanged.
> 
> This introduces new `README.zh-CN.md` files only, including translated setup instructions and reference sections (e.g., DAG runner CLI flags and project structure).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 739dae6200324e302f8327a26644aacedf230acc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->