### PR TITLE
Add Cursor hooks examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 This repo contains small examples for building with Cursor.
 
+## Cursor Hooks
+
+Cursor Hooks let you run custom checks and workflows around agent events such as prompt submission, shell commands, file edits, and agent completion.
+
+### [Hooks examples](hooks)
+
+A guided project hook setup for audit logging, sensitive prompt guards, and follow-up checks that keep Cursor skills aligned with code changes.
+
 ## Cloud Agents
 
 ### [Self-hosted Cloud Agents lab](cloud-agent)

--- a/hooks/.cursor/hooks.json
+++ b/hooks/.cursor/hooks.json
@@ -1,0 +1,54 @@
+{
+  "version": 1,
+  "hooks": {
+    "beforeSubmitPrompt": [
+      {
+        "command": "hooks/.cursor/hooks/audit-log.sh",
+        "matcher": "UserPromptSubmit",
+        "timeout": 5,
+        "failClosed": false
+      },
+      {
+        "command": "hooks/.cursor/hooks/block-models-by-repo-origin.sh",
+        "matcher": "UserPromptSubmit",
+        "timeout": 5,
+        "failClosed": true
+      },
+      {
+        "command": "hooks/.cursor/hooks/sensitive-prompt-guard.sh",
+        "matcher": "UserPromptSubmit",
+        "timeout": 5,
+        "failClosed": true
+      }
+    ],
+    "beforeShellExecution": [
+      {
+        "command": "hooks/.cursor/hooks/audit-log.sh",
+        "timeout": 5,
+        "failClosed": false
+      }
+    ],
+    "afterShellExecution": [
+      {
+        "command": "hooks/.cursor/hooks/audit-log.sh",
+        "timeout": 5,
+        "failClosed": false
+      }
+    ],
+    "afterFileEdit": [
+      {
+        "command": "hooks/.cursor/hooks/audit-log.sh",
+        "timeout": 5,
+        "failClosed": false
+      }
+    ],
+    "stop": [
+      {
+        "command": "node hooks/.cursor/hooks/update-skills-on-stop.mjs",
+        "timeout": 10,
+        "loop_limit": 1,
+        "failClosed": false
+      }
+    ]
+  }
+}

--- a/hooks/.cursor/hooks.json
+++ b/hooks/.cursor/hooks.json
@@ -3,12 +3,6 @@
   "hooks": {
     "beforeSubmitPrompt": [
       {
-        "command": "hooks/.cursor/hooks/audit-log.sh",
-        "matcher": "UserPromptSubmit",
-        "timeout": 5,
-        "failClosed": false
-      },
-      {
         "command": "hooks/.cursor/hooks/block-models-by-repo-origin.sh",
         "matcher": "UserPromptSubmit",
         "timeout": 5,
@@ -19,6 +13,12 @@
         "matcher": "UserPromptSubmit",
         "timeout": 5,
         "failClosed": true
+      },
+      {
+        "command": "hooks/.cursor/hooks/audit-log.sh",
+        "matcher": "UserPromptSubmit",
+        "timeout": 5,
+        "failClosed": false
       }
     ],
     "beforeShellExecution": [

--- a/hooks/.cursor/hooks/audit-log.sh
+++ b/hooks/.cursor/hooks/audit-log.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MAX_PREVIEW_CHARS="${CURSOR_HOOK_LOG_PREVIEW_CHARS:-240}"
+if ! [[ "$MAX_PREVIEW_CHARS" =~ ^[0-9]+$ ]]; then
+  MAX_PREVIEW_CHARS=240
+fi
+
+LOG_DIR="${CURSOR_HOOK_LOG_DIR:-.cursor/hook-logs}"
+LOG_FILE="${LOG_DIR%/}/audit.jsonl"
+VERBOSE=false
+if [[ "${CURSOR_HOOK_LOG_VERBOSE:-}" == "1" ]]; then
+  VERBOSE=true
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'audit-log.sh requires jq on PATH\n' >&2
+  exit 1
+fi
+
+payload="$(cat)"
+if [[ -z "${payload//[[:space:]]/}" ]]; then
+  payload="{}"
+fi
+
+timestamp="$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")"
+
+record="$(
+  jq -c \
+    --arg timestamp "$timestamp" \
+    --argjson max_preview_chars "$MAX_PREVIEW_CHARS" \
+    --argjson verbose "$VERBOSE" \
+    '
+      def preview($max):
+        if type != "string" or length == 0 then
+          null
+        else
+          (gsub("\\s+"; " ") | sub("^\\s+"; "") | sub("\\s+$"; "")) as $normalized
+          | if ($normalized | length) <= $max then
+              $normalized
+            else
+              ($normalized[0:$max] + "...")
+            end
+        end;
+
+      def infer_event:
+        if (.hook_event_name? | type) == "string" then
+          .hook_event_name
+        elif (.prompt? | type) == "string" then
+          "beforeSubmitPrompt"
+        elif (.command? | type) == "string" and (.output? | type) == "string" then
+          "afterShellExecution"
+        elif (.command? | type) == "string" then
+          "beforeShellExecution"
+        elif (.file_path? | type) == "string" and (.edits? | type) == "array" then
+          "afterFileEdit"
+        else
+          "unknown"
+        end;
+
+      (infer_event) as $event
+      | {
+          timestamp: $timestamp,
+          event: $event
+        }
+        + (if .cwd then {cwd: .cwd} else {} end)
+        + (if (.command? | type) == "string" then {command: .command} else {} end)
+        + (if (.prompt? | type) == "string" then
+            {prompt_length: (.prompt | length)}
+            + ((.prompt | preview($max_preview_chars)) as $preview
+              | if $preview == null then {} else {prompt_preview: $preview} end)
+          else
+            {}
+          end)
+        + (if (.attachments? | type) == "array" then {attachments_count: (.attachments | length)} else {} end)
+        + (if (.file_path? | type) == "string" then {file_path: .file_path} else {} end)
+        + (if (.edits? | type) == "array" then {edits_count: (.edits | length)} else {} end)
+        + (if (.duration? | type) == "number" then {duration_ms: .duration} else {} end)
+        + (if (.output? | type) == "string" then
+            {output_length: (.output | length)}
+            + (if $verbose then
+                ((.output | preview($max_preview_chars)) as $preview
+                | if $preview == null then {} else {output_preview: $preview} end)
+              else
+                {}
+              end)
+          else
+            {}
+          end)
+        + (if (.sandbox? | type) == "boolean" then {sandbox: .sandbox} else {} end)
+    ' <<<"$payload"
+)"
+
+mkdir -p "$LOG_DIR"
+printf '%s\n' "$record" >>"$LOG_FILE"
+
+event="$(jq -r '.event' <<<"$record")"
+case "$event" in
+  beforeSubmitPrompt)
+    printf '{"continue":true}\n'
+    ;;
+  beforeShellExecution)
+    printf '{"permission":"allow"}\n'
+    ;;
+  *)
+    printf '{}\n'
+    ;;
+esac

--- a/hooks/.cursor/hooks/block-models-by-repo-origin.sh
+++ b/hooks/.cursor/hooks/block-models-by-repo-origin.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+BLOCKED_REPO_NAMES=(
+  "example"
+)
+
+MODEL_BLOCKLIST=(
+  "example"
+)
+
+allow() {
+  printf '{"continue":true}\n'
+}
+
+deny() {
+  local model="$1"
+  local repo="$2"
+
+  printf '{"continue":false,"user_message":"%s model is not allowed to be used on %s"}\n' "$model" "$repo"
+}
+
+lowercase() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+model_from_payload() {
+  local payload="$1"
+
+  printf '%s' "$payload" \
+    | tr '\n' ' ' \
+    | sed -nE 's/.*"model"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p'
+}
+
+repo_name_from_origin() {
+  local origin="$1"
+  local repo_name="${origin%/}"
+  repo_name="${repo_name##*/}"
+  repo_name="${repo_name%.git}"
+  printf '%s' "$repo_name" | tr '[:upper:]' '[:lower:]'
+}
+
+blocked_repo_match() {
+  local repo_name="$1"
+  local blocked_name
+
+  for blocked_name in "${BLOCKED_REPO_NAMES[@]}"; do
+    blocked_name="$(lowercase "$blocked_name")"
+    if [[ "$repo_name" == *"$blocked_name"* ]]; then
+      printf '%s' "$blocked_name"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+blocked_model_match() {
+  local model="$1"
+  local blocked_model
+
+  for blocked_model in "${MODEL_BLOCKLIST[@]}"; do
+    blocked_model="$(lowercase "$blocked_model")"
+    if [[ "$model" == *"$blocked_model"* ]]; then
+      printf '%s' "$blocked_model"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+payload="$(</dev/stdin)"
+model="$(lowercase "$(model_from_payload "$payload")")"
+
+if [[ -z "$model" ]] || ! matched_model="$(blocked_model_match "$model")"; then
+  allow
+  exit 0
+fi
+
+origin="$(git remote get-url origin 2>/dev/null || true)"
+if [[ -z "$origin" ]]; then
+  allow
+  exit 0
+fi
+
+repo_name="$(repo_name_from_origin "$origin")"
+
+if [[ -n "$repo_name" ]] && matched_repo="$(blocked_repo_match "$repo_name")"; then
+  deny "$matched_model" "$matched_repo"
+  exit 0
+fi
+
+allow

--- a/hooks/.cursor/hooks/sensitive-prompt-guard.sh
+++ b/hooks/.cursor/hooks/sensitive-prompt-guard.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'sensitive-prompt-guard.sh requires jq on PATH\n' >&2
+  exit 1
+fi
+
+payload="$(cat)"
+if [[ -z "${payload//[[:space:]]/}" ]]; then
+  payload="{}"
+fi
+
+prompt="$(jq -r '.prompt // ""' <<<"$payload")"
+prompt_lower="$(printf '%s' "$prompt" | tr '[:upper:]' '[:lower:]')"
+matches=()
+
+add_match() {
+  local name="$1"
+  matches+=("$name")
+}
+
+if [[ "$prompt_lower" =~ -----begin\ (rsa\ |dsa\ |ec\ |openssh\ |pgp\ )?private\ key----- ]]; then
+  add_match "private key"
+fi
+
+if [[ "$prompt" =~ (^|[^[:alnum:]_-])crsr_[A-Za-z0-9_-]{20,}([^[:alnum:]_-]|$) ]]; then
+  add_match "Cursor API key"
+fi
+
+if [[ "$prompt" =~ (^|[^[:alnum:]_])(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{30,}([^[:alnum:]_]|$) ]]; then
+  add_match "GitHub token"
+fi
+
+if [[ "$prompt" =~ (^|[^[:alnum:]_-])xox[baprs]-[A-Za-z0-9-]{20,}([^[:alnum:]_-]|$) ]]; then
+  add_match "Slack token"
+fi
+
+if [[ "$prompt" =~ (^|[^[:alnum:]_-])sk-[A-Za-z0-9_-]{32,}([^[:alnum:]_-]|$) ]]; then
+  add_match "OpenAI API key"
+fi
+
+if [[ "$prompt" =~ (^|[^[:alnum:]_])(AKIA|ASIA)[A-Z0-9]{16}([^[:alnum:]_]|$) ]]; then
+  add_match "AWS access key ID"
+fi
+
+if [[ "$prompt" =~ (^|[^[:alnum:]_-])eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}([^[:alnum:]_-]|$) ]]; then
+  add_match "JWT-like token"
+fi
+
+if [[ "$prompt" =~ (^|[^0-9])([0-9][\ -]*){13,19}([^0-9]|$) ]]; then
+  add_match "credit card-like number"
+fi
+
+if ((${#matches[@]} > 0)); then
+  match_list="${matches[0]}"
+  for match in "${matches[@]:1}"; do
+    match_list+=", ${match}"
+  done
+  message="This prompt appears to contain sensitive data (${match_list}). Remove or replace the sensitive value before resubmitting."
+  jq -cn --arg message "$message" '{"continue":false,"user_message":$message}'
+else
+  printf '{"continue":true}\n'
+fi

--- a/hooks/.cursor/hooks/update-skills-on-stop.mjs
+++ b/hooks/.cursor/hooks/update-skills-on-stop.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+
+const SKILL_MAPPINGS = [
+  {
+    name: "Data access skill",
+    paths: ["src/db/", "db/schema", "schema.ts", "prisma/", "migrations/"],
+    skill: ".cursor/skills/data-access/SKILL.md",
+    checks: ["Refresh generated schema documentation if this repository has a schema-doc generation step."],
+  },
+  {
+    name: "Design system skill",
+    paths: ["src/components/", "components/ui/", "src/app/", "design-system/"],
+    skill: ".cursor/skills/designer/SKILL.md",
+    checks: ["Document new component patterns, variants, tokens, or layout conventions."],
+  },
+  {
+    name: "Cursor integration skill",
+    paths: ["src/lib/cursor/", "lib/cursor/", "cursor/"],
+    skill: ".cursor/skills/cursor/SKILL.md",
+    checks: ["Document new Cursor API helpers, agent workflow changes, or integration caveats."],
+  },
+];
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let input = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => {
+      input += chunk;
+    });
+    process.stdin.on("end", () => resolve(input));
+    process.stdin.on("error", reject);
+  });
+}
+
+function gitLines(args) {
+  try {
+    return execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] })
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function changedFiles() {
+  const tracked = gitLines(["diff", "--name-only", "HEAD"]);
+  const untracked = gitLines(["ls-files", "--others", "--exclude-standard"]);
+  return [...new Set([...tracked, ...untracked])].sort();
+}
+
+function normalizePath(filePath) {
+  return filePath.replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
+function matchesPrefixOrFile(filePath, matcher) {
+  const normalizedFile = normalizePath(filePath);
+  const normalizedMatcher = normalizePath(matcher);
+
+  if (normalizedMatcher.endsWith("/")) {
+    return normalizedFile.startsWith(normalizedMatcher);
+  }
+
+  return normalizedFile === normalizedMatcher || normalizedFile.endsWith(`/${normalizedMatcher}`);
+}
+
+function matchingMappings(files) {
+  return SKILL_MAPPINGS.map((mapping) => {
+    const matchedFiles = files.filter((file) =>
+      mapping.paths.some((pathPattern) => matchesPrefixOrFile(file, pathPattern)),
+    );
+
+    return { ...mapping, matchedFiles };
+  }).filter((mapping) => mapping.matchedFiles.length > 0);
+}
+
+function buildFollowup(matches) {
+  const sections = matches.map((match) => {
+    const files = match.matchedFiles.map((file) => `- ${file}`).join("\n");
+    const checks = match.checks.map((check) => `- ${check}`).join("\n");
+
+    return [
+      `${match.name}: ${match.skill}`,
+      "Changed files:",
+      files,
+      "Checks:",
+      checks,
+    ].join("\n");
+  });
+
+  return [
+    "Before finishing, review whether related Cursor skills need updates because this run changed files in configured areas.",
+    "",
+    sections.join("\n\n"),
+    "",
+    "If a skill is stale, update it now. If no update is needed, briefly explain why. Then run the relevant verification for the files you changed.",
+  ].join("\n");
+}
+
+const input = await readStdin();
+const payload = JSON.parse(input || "{}");
+
+if (payload.status && payload.status !== "completed") {
+  console.log(JSON.stringify({}));
+  process.exit(0);
+}
+
+if (Number(payload.loop_count || 0) > 0) {
+  console.log(JSON.stringify({}));
+  process.exit(0);
+}
+
+const matches = matchingMappings(changedFiles());
+
+if (matches.length === 0) {
+  console.log(JSON.stringify({}));
+} else {
+  console.log(JSON.stringify({ followup_message: buildFollowup(matches) }));
+}

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,86 @@
+# Cursor Hooks Examples
+
+This folder is a guided [Cursor Hooks](https://cursor.com/docs/hooks) example. It follows a project-style layout: one hook configuration file and a shared scripts directory that demonstrate multiple hook patterns together.
+
+## Project Layout
+
+```sh
+hooks/
+├── README.md
+└── .cursor/
+    ├── hooks.json
+    └── hooks/
+        ├── audit-log.sh
+        ├── block-models-by-repo-origin.sh
+        ├── sensitive-prompt-guard.sh
+        └── update-skills-on-stop.mjs
+```
+
+## What It Shows
+
+### Additional logging
+
+`audit-log.sh` writes a JSONL audit trail for prompt submissions, shell commands, shell results, and file edits. By default, logs are written to `.cursor/hook-logs/audit.jsonl` from the project root.
+
+The destination does not have to be a local JSONL file. The same pattern can send records to a personal logging script, an internal company audit service, a SIEM, or any other logging tool your team owns.
+
+### Sensitive prompt guard
+
+`sensitive-prompt-guard.sh` blocks prompts that appear to contain secrets or sensitive data. `beforeSubmitPrompt` can prevent submission to Cursor's backend systems and models, but it cannot rewrite or redact prompt text in place.
+
+A similar hook can also hand the prompt to a DLP service, secret scanner, or other internal security tool and block submission when that system returns a sensitive finding.
+
+### Model/repo prompt blocking
+
+`block-models-by-repo-origin.sh` blocks prompt submissions when both the selected model and the git origin repo name match configured substring lists. The hook reads `model` from the `beforeSubmitPrompt` payload, runs `git remote get-url origin` from the project root, extracts the repo name from the URL, and uses broad substring matching against `MODEL_BLOCKLIST` and `BLOCKED_REPO_NAMES`. The sample values use `example` for both lists, so an `example` model is blocked on repos like `git@github.com:{org}/example.git` or `https://github.com/{org}/example-app.git`.
+
+The matching is intentionally broad: conceptually, it behaves like checking whether a blocked repo string appears anywhere in the repo name returned from the git remote. This may match more than an exact repository name. The sample hook is configured with `failClosed: true`, so crashes, timeouts, or invalid JSON fail closed, but the script intentionally returns `continue: true` when no git `origin` remote exists.
+
+### Skill update follow-up
+
+`update-skills-on-stop.mjs` runs on `stop`, checks changed files, and asks the agent to update related `.cursor/skills/*/SKILL.md` files when configured code areas changed.
+
+This can be used as a way for skills to be self-maintaining over time.
+
+## Using These Examples
+
+Copy the `hooks/` folder into your project, then merge `hooks/.cursor/hooks.json` into your project hook configuration at `.cursor/hooks.json`. The sample commands assume the scripts remain at `hooks/.cursor/hooks/*` and run from the project root:
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "beforeSubmitPrompt": [
+      {
+        "command": "hooks/.cursor/hooks/sensitive-prompt-guard.sh",
+        "matcher": "UserPromptSubmit",
+        "failClosed": true
+      }
+    ]
+  }
+}
+```
+
+If you prefer Cursor's conventional project-hook location, move the scripts into `.cursor/hooks/` and update the command paths to match.
+
+You can comment out or remove any hooks you do not want to enable.
+
+## Customization
+
+- Edit `BLOCKED_REPO_NAMES` and `MODEL_BLOCKLIST` in `block-models-by-repo-origin.sh` to block specific model/repository substring combinations.
+- Edit the patterns in `sensitive-prompt-guard.sh` to tune prompt blocking.
+- Edit `SKILL_MAPPINGS` in `update-skills-on-stop.mjs` to map code paths to your own skills.
+- Set `CURSOR_HOOK_LOG_DIR` to change the audit log directory.
+- Set `CURSOR_HOOK_LOG_VERBOSE=1` to include shell output previews in audit logs.
+
+## Notes
+
+- Project hooks run from the project root.
+- Trusted workspaces automatically load project hooks from `.cursor/hooks.json`. Similarly, you can define these hooks at a user level `~/.cursor` or organizational level (on cursor.com/dashboard).
+- `audit-log.sh` uses `bash` and `jq`; verify those are available in the hook environment before enabling it.
+- `block-models-by-repo-origin.sh` uses `git` and `bash`; verify those are available in the hook environment before enabling it.
+- `sensitive-prompt-guard.sh` uses `bash` and `jq`; verify those are available in the hook environment before enabling it.
+- `beforeSubmitPrompt` can block local prompt submission, but it is not available for cloud agents because the prompt is submitted before the cloud VM exists.
+- Use an additional `subagentStart` hook if you also need to block subagents by model; `beforeSubmitPrompt` only covers the prompt submission that starts the main request.
+- Logging hooks can capture sensitive information. Review what this example records before enabling it in a real repository.
+


### PR DESCRIPTION
#### 💻 Change Type

- [x] docs    <!-- Documentation only changes -->
- [x] chore    <!-- Other changes that don't modify src or test files -->

#### 🔀 Description of Change

Add a guided Cursor Hooks examples folder with sample project hook configuration and scripts for audit logging, sensitive prompt guarding, model/repo prompt blocking, and skill update follow-ups. The top-level README now links to the hooks examples so they are discoverable from the cookbook index.

#### 📝 Additional Information

Validation run:
- `jq empty hooks/.cursor/hooks.json`
- `bash -n hooks/.cursor/hooks/audit-log.sh hooks/.cursor/hooks/block-models-by-repo-origin.sh hooks/.cursor/hooks/sensitive-prompt-guard.sh`
- `node --check hooks/.cursor/hooks/update-skills-on-stop.mjs`
- sample `sensitive-prompt-guard.sh` allow/block payload checks

No root build or unit test suite was present for these documentation/example changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and sample hook scripts only; no application or production runtime changes.
> 
> **Overview**
> Adds a **Cursor Hooks** cookbook section and a new `hooks/` example you can copy into projects: sample `.cursor/hooks.json` plus scripts for audit logging, blocking sensitive prompts, optional model/repo prompt blocking, and a `stop` hook that nudges skill doc updates when mapped paths change.
> 
> The root **README** now links to `hooks/` so the examples sit alongside Cloud Agents and SDK entries. `hooks/README.md` documents layout, how to merge config, and customization (blocklists, patterns, `SKILL_MAPPINGS`, log env vars).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36fde23c08af4ac49f8fc1b2f52851aca5859d18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->