### PR TITLE
Fix link to Self-hosted Cloud Agents lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A guided project hook setup for audit logging, sensitive prompt guards, and foll
 
 ## Cloud Agents
 
-### [Self-hosted Cloud Agents lab](cloud-agent)
+### [Self-hosted Cloud Agents lab](self-hosted-cloud-agent)
 
 Run Cursor Cloud Agent workers on customer-managed AWS infrastructure with examples for EC2 + Docker, ECS/Fargate, and EKS + Helm.
 


### PR DESCRIPTION
Previous link (https://github.com/cursor/cookbook/blob/main/cloud-agent) led to a 404 error. This fixes it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link correction with no runtime or security impact.
> 
> **Overview**
> Updates the **Self-hosted Cloud Agents lab** link in `README.md` from `cloud-agent` to `self-hosted-cloud-agent` so it points at the actual lab directory instead of a broken path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82c57ed9d376b02c896aecf72a0fe6d9a3571a39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->