### PR TITLE
Set up Cursor Cloud dev environment + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo (the **Cursor Cookbook**) is a collection of independent example projects, not one app.
+Each lives in its own directory with its own `pnpm-lock.yaml`; there is no root workspace and there
+are **no automated tests**. Standard per-project commands live in each project's `package.json`
+(`dev`/`build`/`start`/`lint`/`typecheck`) and in the top-level `README.md`.
+
+Projects:
+- `sdk/quickstart` — Node/tsx CLI; runs one local agent and streams the reply.
+- `sdk/dag-task-runner` — Node/tsx CLI; decomposes a task into a DAG of subagents and renders a Cursor Canvas.
+- `sdk/coding-agent-cli` — terminal TUI; **must run with Bun** (its renderer uses `bun:ffi`).
+- `sdk/app-builder` — Next.js web app (App Router).
+- `sdk/agent-kanban` — Next.js web app; lists/creates Cursor Cloud Agents.
+- `hooks/` and `self-hosted-cloud-agent/` — Cursor Hooks scripts and AWS IaC (Docker/Terraform/Helm); optional, no build.
+
+### Non-obvious gotchas
+
+- **API key**: every SDK example needs a Cursor API key (`crsr_...`). The SDK and both web apps read
+  `process.env.CURSOR_API_KEY`, which is **not** set in this environment. A valid key is available as
+  `CURSOR_SERVICE_ACCOUNT_KEY`, so run the SDK examples with `CURSOR_API_KEY="$CURSOR_SERVICE_ACCOUNT_KEY"`.
+  This service-account key authenticates and lists cloud agents/models, but has **no GitHub repository
+  integration**, so repository pickers in the web apps come back empty (expected, not a bug).
+- **Bun** is required only by `sdk/coding-agent-cli`. It is installed at `~/.local/bin/bun` and added to
+  `PATH` via `~/.bashrc`. `bun.sh`'s install script is blocked by egress; if Bun is ever missing,
+  reinstall with `npm i -g bun` (the npm package downloads the binary from the registry). The TUI needs a
+  real TTY — run it in a tmux/interactive shell, not as a piped background process.
+- **Web apps default to port 3000.** To run `app-builder` and `agent-kanban` at the same time, give one a
+  different port, e.g. `PORT=3001 pnpm dev`.
+- The web apps persist their key to `~/.app-builder/settings.json` / `~/.agent-kanban/settings.json`. You
+  can seed `{"cursorApiKey": "<crsr_...>"}` there to skip the in-UI key prompt; the app validates it via
+  `Cursor.me()` on load.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the **Cursor Cookbook** (a collection of independent SDK example projects, Cursor Hooks scripts, and a self-hosted Cloud Agent IaC lab) and adds `AGENTS.md` documenting durable, non-obvious setup/run caveats for future cloud agents.

No application code was changed — only `AGENTS.md` was added.

## Environment setup

- Installed dependencies for all 5 `sdk/*` projects via `pnpm install` (corepack pins pnpm 10.9.0).
- Installed Bun (`~/.local/bin/bun`, added to `PATH`) for `sdk/coding-agent-cli`, since `bun.sh`'s installer is egress-blocked.
- The SDK reads `CURSOR_API_KEY`, which is unset; the env provides a valid `CURSOR_SERVICE_ACCOUNT_KEY` that can be mapped to it.

**Update script** (minimal dependency refresh): `pnpm -C <dir> install` for each of the 5 `sdk/*` projects.

## Verification

| Project | lint | typecheck | build | run |
|---|---|---|---|---|
| `sdk/quickstart` | — | ✅ | ✅ | ✅ real local agent run |
| `sdk/dag-task-runner` | — | ✅ | ✅ | ✅ `init-canvas` renders canvas |
| `sdk/coding-agent-cli` | — | ✅ (Bun) | — | — (interactive TUI) |
| `sdk/app-builder` | ✅ | — | ✅ | ✅ dev server :3000 |
| `sdk/agent-kanban` | ✅ | — | ✅ | ✅ dev server :3001, lists real cloud agents |

### Agent Kanban demo
<a href="https://cursor.com/agents/bc-246db1b8-0983-45d2-801c-319fde2024f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_kanban_demo.mp4"><img src="https://cursor.com/artifacts/c/art-a68f1eb4-8d56-4a54-9a59-33a841a20e86" alt="agent_kanban_demo.mp4" /></a>
![Agent Kanban board with real cloud agents](https://cursor.com/artifacts/c/art-5c5402b0-6a7e-4e82-97ab-084b69f91585)
![Create cloud agent form](https://cursor.com/artifacts/c/art-1c6a5d41-601d-481a-a217-5aef83e51ff0)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-246db1b8-0983-45d2-801c-319fde2024f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-246db1b8-0983-45d2-801c-319fde2024f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

