### PR TITLE
Rename Cookbook to Sciencebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cursor Cookbook
+# Cursor Sciencebook
 
 This repo contains small examples for building with Cursor.
 

--- a/sdk/dag-task-runner/README.md
+++ b/sdk/dag-task-runner/README.md
@@ -43,12 +43,12 @@ Run the included example DAG end-to-end:
 pnpm example
 ```
 
-The example builds a tiny single-file CLI todo app. Tasks run against `process.cwd()` by default, so use a scratch directory if you don't want files written into the cookbook:
+The example builds a tiny single-file CLI todo app. Tasks run against `process.cwd()` by default, so use a scratch directory if you don't want files written into the sciencebook:
 
 ```bash
 mkdir -p /tmp/dag-demo && cd /tmp/dag-demo
 CURSOR_API_KEY="crsr_..." \
-  pnpm --dir ~/Code/cookbook/sdk/dag-task-runner \
+  pnpm --dir ~/Code/sciencebook/sdk/dag-task-runner \
   dev -- --dag examples/example_dag.json --canvas-path "$PWD/dag-example.canvas.tsx" --cwd "$PWD"
 ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the app to refer to "Sciencebook" instead of "Cookbook" everywhere.

## Changes

- `README.md`: Updated the top-level heading from `# Cursor Cookbook` to `# Cursor Sciencebook`.
- `sdk/dag-task-runner/README.md`: Updated two references:
  - "files written into the cookbook" → "files written into the sciencebook"
  - `~/Code/cookbook/sdk/dag-task-runner` → `~/Code/sciencebook/sdk/dag-task-runner`

Verified there are no remaining (case-insensitive) references to "cookbook" in the codebase.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-585102cb-4e05-4dab-9d36-7f386cb995d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-585102cb-4e05-4dab-9d36-7f386cb995d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

