### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A guided project hook setup for audit logging, sensitive prompt guards, and foll
 
 ## Cloud Agents
 
-### [Self-hosted Cloud Agents lab](cloud-agent)
+### [Self-hosted Cloud Agents lab](self-hosted-cloud-agent)
 
 Run Cursor Cloud Agent workers on customer-managed AWS infrastructure with examples for EC2 + Docker, ECS/Fargate, and EKS + Helm.
 


### PR DESCRIPTION
at Cursor Cafe w/ Morgan

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link correction with no runtime or security impact.
> 
> **Overview**
> Updates the **Self-hosted Cloud Agents lab** link in `README.md` from `cloud-agent` to `self-hosted-cloud-agent` so it matches the example directory in the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b97c95f870f3a25a9a7ada2a01e66f3481e8b02b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->