### PR TITLE
Add MCP execution audit hook example

### DIFF
--- a/hooks/.cursor/hooks.json
+++ b/hooks/.cursor/hooks.json
@@ -35,6 +35,13 @@
         "failClosed": false
       }
     ],
+    "afterMCPExecution": [
+      {
+        "command": "node hooks/.cursor/hooks/audit-mcp-execution.mjs",
+        "timeout": 5,
+        "failClosed": false
+      }
+    ],
     "afterFileEdit": [
       {
         "command": "hooks/.cursor/hooks/audit-log.sh",

--- a/hooks/.cursor/hooks/audit-mcp-execution.mjs
+++ b/hooks/.cursor/hooks/audit-mcp-execution.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+/**
+ * Audit an afterMCPExecution payload without writing tool arguments or results
+ * to the log by default. Hook scripts must not block the agent, so malformed
+ * input and filesystem errors are reported on stderr and exit successfully.
+ */
+
+import { appendFile, mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+
+const SENSITIVE_KEY = /token|secret|password|passwd|api[_-]?key|authorization|cookie|credential|private[_-]?key/i;
+const MAX_KEYS = 100;
+const MAX_PREVIEW = 240;
+
+function redact(value, seen = new WeakSet()) {
+  if (value === null || typeof value !== "object") return value;
+  if (seen.has(value)) return "[Circular]";
+  seen.add(value);
+
+  if (Array.isArray(value)) return value.slice(0, MAX_KEYS).map((item) => redact(item, seen));
+
+  const result = {};
+  for (const [key, item] of Object.entries(value).slice(0, MAX_KEYS)) {
+    result[key] = SENSITIVE_KEY.test(key) ? "[REDACTED]" : redact(item, seen);
+  }
+  return result;
+}
+
+function parseJson(value) {
+  if (typeof value !== "string" || value.trim() === "") return null;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+function preview(value) {
+  if (typeof value !== "string" || value.length === 0) return null;
+  const normalized = value.replace(/\s+/g, " ").trim();
+  return normalized.length > MAX_PREVIEW ? `${normalized.slice(0, MAX_PREVIEW)}...` : normalized;
+}
+
+function makeRecord(payload) {
+  const input = parseJson(payload.tool_input);
+  const result = parseJson(payload.result_json);
+  const record = {
+    timestamp: new Date().toISOString(),
+    event: "afterMCPExecution",
+    tool_name: typeof payload.tool_name === "string" ? payload.tool_name : null,
+    duration_ms: typeof payload.duration === "number" ? payload.duration : null,
+    // Cursor's documented payload does not currently contain server identity.
+    // Preserve it when a future/runtime-specific payload provides one.
+    server: typeof payload.server_name === "string"
+      ? payload.server_name
+      : typeof payload.mcp_server === "string"
+        ? payload.mcp_server
+        : null,
+    tool_input: input === null
+      ? { type: typeof payload.tool_input, length: String(payload.tool_input ?? "").length }
+      : {
+          type: Array.isArray(input) ? "array" : typeof input,
+          keys: input && typeof input === "object" && !Array.isArray(input)
+            ? Object.keys(input).slice(0, MAX_KEYS)
+            : [],
+        },
+    result: {
+      type: result === null ? typeof payload.result_json : "json",
+      length: typeof payload.result_json === "string" ? payload.result_json.length : 0,
+      has_error: Boolean(result && (result.error || result.isError)),
+    },
+  };
+
+  if (process.env.CURSOR_MCP_AUDIT_VERBOSE === "1") {
+    if (input !== null) record.tool_input = redact(input);
+    const resultPreview = preview(payload.result_json);
+    if (resultPreview !== null) record.result.preview = preview(JSON.stringify(redact(result)) || resultPreview);
+  }
+  return record;
+}
+
+const payloadText = await new Promise((resolve) => {
+  let text = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk) => { text += chunk; });
+  process.stdin.on("end", () => resolve(text));
+});
+
+try {
+  const payload = JSON.parse(payloadText || "{}");
+  const record = makeRecord(payload);
+  const logFile = process.env.CURSOR_MCP_AUDIT_LOG || ".cursor/hook-logs/mcp-execution.jsonl";
+  await mkdir(dirname(logFile), { recursive: true });
+  await appendFile(logFile, `${JSON.stringify(record)}\n`, { mode: 0o600 });
+} catch (error) {
+  // Auditing is observational; it must never turn an MCP call into a failure.
+  console.error(`MCP audit hook: ${error instanceof Error ? error.message : String(error)}`);
+}

--- a/hooks/.cursor/hooks/test-audit-mcp-execution.mjs
+++ b/hooks/.cursor/hooks/test-audit-mcp-execution.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+
+const hook = new URL("./audit-mcp-execution.mjs", import.meta.url);
+const hookPath = hook.pathname;
+
+function run(input, env = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [hookPath], {
+      env: { ...process.env, ...env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stderr = "";
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("error", reject);
+    child.on("close", (code) => resolve({ code, stderr }));
+    child.stdin.end(JSON.stringify(input));
+  });
+}
+
+const directory = await mkdtemp(join(tmpdir(), "cursor-mcp-audit-"));
+const logFile = join(directory, "audit.jsonl");
+try {
+  const result = await run({
+    tool_name: "search_contacts",
+    tool_input: JSON.stringify({ query: "Ada", api_key: "do-not-log" }),
+    result_json: JSON.stringify({ contacts: [{ name: "Ada" }] }),
+    duration: 42,
+  }, { CURSOR_MCP_AUDIT_LOG: logFile });
+  if (result.code !== 0) throw new Error(`hook exited ${result.code}: ${result.stderr}`);
+
+  const record = JSON.parse((await readFile(logFile, "utf8")).trim());
+  if (record.event !== "afterMCPExecution") throw new Error("event was not recorded");
+  if (record.tool_name !== "search_contacts") throw new Error("tool name was not recorded");
+  if (record.duration_ms !== 42) throw new Error("duration was not recorded");
+  if (record.server !== null) throw new Error("unknown server must remain null");
+  if (!record.tool_input.keys.includes("api_key")) throw new Error("input keys were not recorded");
+  if (JSON.stringify(record).includes("do-not-log")) throw new Error("secret leaked into audit record");
+  if (record.result.preview !== undefined) throw new Error("result preview leaked without verbose mode");
+
+  const malformed = await run({ tool_name: "broken", tool_input: "not-json", result_json: "not-json" }, {
+    CURSOR_MCP_AUDIT_LOG: logFile,
+  });
+  if (malformed.code !== 0) throw new Error("malformed optional fields should not fail the hook");
+
+  console.log("audit-mcp-execution: all tests passed");
+} finally {
+  await rm(directory, { recursive: true, force: true });
+}

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -36,6 +36,20 @@ A similar hook can also hand the prompt to a DLP service, secret scanner, or oth
 
 The matching is intentionally broad: conceptually, it behaves like checking whether a blocked repo string appears anywhere in the repo name returned from the git remote. This may match more than an exact repository name. The sample hook is configured with `failClosed: true`, so crashes, timeouts, or invalid JSON fail closed, but the script intentionally returns `continue: true` when no git `origin` remote exists.
 
+### MCP execution audit
+
+`audit-mcp-execution.mjs` is an observational `afterMCPExecution` hook. It records a redacted JSONL audit event at `.cursor/hook-logs/mcp-execution.jsonl` by default. The record includes the tool name, duration, input shape, input keys, result size, and whether the result reports an error.
+
+Tool arguments and MCP results are not written by default. Keys that commonly contain credentials (such as `api_key`, `token`, `password`, and `authorization`) are redacted if verbose logging is enabled. Set `CURSOR_MCP_AUDIT_LOG` to change the destination or `CURSOR_MCP_AUDIT_VERBOSE=1` to include bounded previews after reviewing the privacy implications.
+
+The documented `afterMCPExecution` payload currently includes `tool_name`, `tool_input`, `result_json`, and `duration`; it does not include the MCP server identity. The audit record therefore uses `server: null` rather than guessing a server from the tool name. If a runtime-specific payload supplies `server_name` or `mcp_server`, that value is retained.
+
+Run the self-contained test with:
+
+```bash
+node hooks/.cursor/hooks/test-audit-mcp-execution.mjs
+```
+
 ### Skill update follow-up
 
 `update-skills-on-stop.mjs` runs on `stop`, checks changed files, and asks the agent to update related `.cursor/skills/*/SKILL.md` files when configured code areas changed.


### PR DESCRIPTION
## What this PR adds

This PR adds a copyable example for auditing MCP tool calls made by Cursor Agent.

When an MCP tool finishes, Cursor runs the configured `afterMCPExecution` hook. The new hook reads that event and appends one JSON object per line to:

```text
.cursor/hook-logs/mcp-execution.jsonl
```

Example record:

```json
{
  "timestamp": "2026-08-20T12:44:33.693Z",
  "event": "afterMCPExecution",
  "tool_name": "search_contacts",
  "duration_ms": 42,
  "server": null,
  "tool_input": {
    "type": "object",
    "keys": ["query", "api_key"]
  },
  "result": {
    "type": "json",
    "length": 29,
    "has_error": false
  }
}
```

## Privacy and safety

The default mode does **not** write MCP arguments or results to disk. It records only the input shape and field names, result size, duration, and error status.

If verbose mode is explicitly enabled with `CURSOR_MCP_AUDIT_VERBOSE=1`, credential-like fields such as `api_key`, `token`, `password`, and `authorization` are redacted. The hook also limits previews and handles malformed input without failing the MCP call.

The log location can be changed with:

```bash
CURSOR_MCP_AUDIT_LOG=/path/to/mcp-execution.jsonl
```

## MCP server identity

The documented `afterMCPExecution` payload currently contains:

- `tool_name`
- `tool_input`
- `result_json`
- `duration`

It does not currently contain the MCP server name. The example therefore records `server: null` rather than guessing the server from a tool name. If a runtime-specific payload provides `server_name` or `mcp_server`, the hook preserves it.

## Files changed

- `hooks/.cursor/hooks.json` — registers the new hook
- `hooks/.cursor/hooks/audit-mcp-execution.mjs` — implementation
- `hooks/.cursor/hooks/test-audit-mcp-execution.mjs` — self-contained test
- `hooks/README.md` — setup and usage documentation

## Testing

Passed locally:

```bash
node hooks/.cursor/hooks/test-audit-mcp-execution.mjs
node -e "JSON.parse(require('fs').readFileSync('hooks/.cursor/hooks.json'))"
git diff --check
```

The hook is observational and uses `failClosed: false`, so an audit/logging problem cannot turn a successful MCP call into a failed agent operation.
