### PR TITLE
Export a public reconnect/retry signal for TypeScript SDK embedders

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ A minimal command-line interface that lets you spawn Cursor agents from your ter
 
 Decompose a task into a JSON DAG, fan it out across local subagents, and stream live status into a Cursor Canvas that hot-reloads on every state change. Ships as both a runnable example and a copyable Cursor skill at [`.cursor/skills/dag-task-runner`](.cursor/skills/dag-task-runner).
 
+### [Reconnect / retry signal](sdk/reconnect-signal)
+
+Public `onConnectionStateChange` and `RETRYING` stream status for headless `@cursor/sdk` embedders. Pause idle timeouts while the SDK is reconnecting so a transport retry is not mistaken for a dead model.
+
 ### [Perl bridge adapter](sdk/perl-bridge-adapter)
 
 A miniature Cursor SDK in Perl on the open [`sdk.v1` bridge](https://github.com/cursor/sdk-bridge). Shows how to spawn `cursor-sdk-bridge`, speak Connect JSON, and run one local agent turn without a first-party SDK.

--- a/sdk/reconnect-signal/.gitignore
+++ b/sdk/reconnect-signal/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/sdk/reconnect-signal/README.md
+++ b/sdk/reconnect-signal/README.md
@@ -1,0 +1,70 @@
+# Reconnect / retry signal
+
+Headless embedders keep `local.enableAgentRetries: true` so a stalled transport can recover. `@cursor/sdk` already has a stall detector and an `onConnectionStateChange` hook (`reconnecting` / `connected`), but those are not on the public TypeScript surface. There is also no stream status for `RETRYING`.
+
+Without that signal, an idle timeout cannot tell model silence from an in-progress SDK reconnect. This example exports the missing public hook so embedders can keep retries enabled and still observe them.
+
+```ts
+import { Agent } from "@cursor/sdk"
+import {
+  createConnectionStateHub,
+  createReconnectAwareIdleTimer,
+  watchStream,
+} from "./src/reconnect.js"
+
+const hub = createConnectionStateHub()
+
+await using agent = await Agent.create({
+  apiKey: process.env.CURSOR_API_KEY!,
+  model: { id: "composer-2" },
+  local: {
+    cwd: process.cwd(),
+    enableAgentRetries: true,
+    // Typed extra field. The SDK already calls this internally; it is not
+    // forwarded today. Keep it so a future release can light up the hook.
+    onConnectionStateChange: hub.notify,
+  },
+})
+
+const idle = createReconnectAwareIdleTimer({
+  idleMs: 60_000,
+  isRetrying: () => hub.isRetrying(),
+  onIdle: () => {
+    throw new Error("idle timeout: model silence")
+  },
+})
+
+const run = await agent.send("Summarize this repository.")
+idle.start()
+
+for await (const event of watchStream(run.stream(), hub)) {
+  if (event.type === "status" && event.status === "RETRYING") {
+    console.log("SDK is reconnecting; idle clock is paused")
+  }
+  idle.touch()
+}
+
+idle.stop()
+await run.wait()
+```
+
+`watchStream` yields a `status: "RETRYING"` event whenever the hub reports `reconnecting`. The idle timer freezes for that window and resumes after `connected`, so a transport retry is not logged as a dead model.
+
+## Getting started
+
+Use Node.js 22 or newer.
+
+```bash
+pnpm install
+pnpm test
+pnpm dev
+```
+
+`pnpm dev` runs a simulated reconnect so you can see `RETRYING` and the paused idle clock without an API key.
+
+To attach the same helper to a live local agent:
+
+```bash
+export CURSOR_API_KEY="crsr_..."
+pnpm dev -- --live
+```

--- a/sdk/reconnect-signal/package.json
+++ b/sdk/reconnect-signal/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "sdk-reconnect-signal",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@10.9.0",
+  "engines": {
+    "node": ">=22"
+  },
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test src/reconnect.test.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^25.6.0",
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.3"
+  },
+  "dependencies": {
+    "@cursor/sdk": "^1.0.30"
+  }
+}

--- a/sdk/reconnect-signal/pnpm-lock.yaml
+++ b/sdk/reconnect-signal/pnpm-lock.yaml
@@ -1,0 +1,466 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@cursor/sdk':
+        specifier: ^1.0.30
+        version: 1.0.30
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.9.5
+      tsx:
+        specifier: ^4.21.0
+        version: 4.23.12
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
+packages:
+
+  '@bufbuild/protobuf@1.10.0':
+    resolution: {integrity: sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==}
+
+  '@connectrpc/connect-node@1.7.0':
+    resolution: {integrity: sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@bufbuild/protobuf': ^1.10.0
+      '@connectrpc/connect': 1.7.0
+
+  '@connectrpc/connect-web@1.7.0':
+    resolution: {integrity: sha512-qyP0YOnUPRWwCc/VfsoydMJvkb7EyUPr2q9sHgBuJzbADjiqck1gKH5V5ZPzPhTLBvmz5UvG+wiZ5sMRQHU1MQ==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^1.10.0
+      '@connectrpc/connect': 1.7.0
+
+  '@connectrpc/connect@1.7.0':
+    resolution: {integrity: sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^1.10.0
+
+  '@cursor/sdk-darwin-arm64@1.0.30':
+    resolution: {integrity: sha512-O0w2fLd6jxrvAUOJGsKBs8VSi5OojqqEOMFBzHTHS82wU/DX3ZlizK3czzCXxDKs3l8j/BVQwVCxP9jMFcf41Q==}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
+  '@cursor/sdk-darwin-x64@1.0.30':
+    resolution: {integrity: sha512-TdjreV7V6gtSKbUaXDarfE1735PES6uzLgLxp42E5kT6EXpjQhKsifdsYOMdsO/RBw166kya/XxG24L/FUfEHA==}
+    cpu: [x64]
+    os: [darwin]
+    hasBin: true
+
+  '@cursor/sdk-linux-arm64@1.0.30':
+    resolution: {integrity: sha512-1+bsmri6vJ2YuqL/SQ6QSx/ymu2eBzjGgT1bTgN47tCzxDgNOKacXtghpx4zdHM5AmOtT+aLXVVxXjStXmNtcA==}
+    cpu: [arm64]
+    os: [linux]
+    hasBin: true
+
+  '@cursor/sdk-linux-x64@1.0.30':
+    resolution: {integrity: sha512-5TRAM1xNwVr0Lox2ay5U5h+VY1OeqJLgnS28da7mx+ZkmeAU+hzuUFq2/lcIqoJrp2qBRdUH5WzI44JNtjBKmg==}
+    cpu: [x64]
+    os: [linux]
+    hasBin: true
+
+  '@cursor/sdk-win32-x64@1.0.30':
+    resolution: {integrity: sha512-kVjpWmLTFLL131TQm3ytz1HbAeyjBRAHMtr6vyLtbBMuLBb0la5igvt58Xi8mXwekymWXim1+rZj7ZYUO3K1rw==}
+    cpu: [x64]
+    os: [win32]
+    hasBin: true
+
+  '@cursor/sdk@1.0.30':
+    resolution: {integrity: sha512-s3gIXfTD3w8ys+KFE81JjjoiJcynkHsf/JCDyXrnbliIac3dkT59hwYZII3XhsT1DlXIfqg+YzSMru6w1CkZow==}
+    engines: {node: '>=22.13'}
+
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
+
+  '@statsig/client-core@3.31.0':
+    resolution: {integrity: sha512-SuxQD6TmVszPG7FoMKwTk/uyBuVFk7XnxI3T/E0uyb7PL7GNjONtfsoh+NqBBVUJVse0CUeSFfgJPoZy1ZOslQ==}
+
+  '@statsig/js-client@3.31.0':
+    resolution: {integrity: sha512-LFa5E0LjT6sTfZv3sNGoyRLSZ1078+agdgOA+Vm1ecjG+KbSOfBLTW7hMwimrJ29slRwbYDzbtKaPJo/R37N2g==}
+
+  '@types/node@25.9.5':
+    resolution: {integrity: sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==}
+
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  tsx@4.23.12:
+    resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@bufbuild/protobuf@1.10.0': {}
+
+  '@connectrpc/connect-node@1.7.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0))':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+      '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.0)
+      undici: 5.29.0
+
+  '@connectrpc/connect-web@1.7.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0))':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+      '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.0)
+
+  '@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0)':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+
+  '@cursor/sdk-darwin-arm64@1.0.30':
+    optional: true
+
+  '@cursor/sdk-darwin-x64@1.0.30':
+    optional: true
+
+  '@cursor/sdk-linux-arm64@1.0.30':
+    optional: true
+
+  '@cursor/sdk-linux-x64@1.0.30':
+    optional: true
+
+  '@cursor/sdk-win32-x64@1.0.30':
+    optional: true
+
+  '@cursor/sdk@1.0.30':
+    dependencies:
+      '@bufbuild/protobuf': 1.10.0
+      '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.0)
+      '@connectrpc/connect-node': 1.7.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0))
+      '@connectrpc/connect-web': 1.7.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0))
+      '@statsig/js-client': 3.31.0
+      zod: 3.25.76
+    optionalDependencies:
+      '@cursor/sdk-darwin-arm64': 1.0.30
+      '@cursor/sdk-darwin-x64': 1.0.30
+      '@cursor/sdk-linux-arm64': 1.0.30
+      '@cursor/sdk-linux-x64': 1.0.30
+      '@cursor/sdk-win32-x64': 1.0.30
+
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
+    optional: true
+
+  '@fastify/busboy@2.1.1': {}
+
+  '@statsig/client-core@3.31.0': {}
+
+  '@statsig/js-client@3.31.0':
+    dependencies:
+      '@statsig/client-core': 3.31.0
+
+  '@types/node@25.9.5':
+    dependencies:
+      undici-types: 7.24.6
+
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
+
+  fsevents@2.3.3:
+    optional: true
+
+  tsx@4.23.12:
+    dependencies:
+      esbuild: 0.28.2
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@6.0.3: {}
+
+  undici-types@7.24.6: {}
+
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
+
+  zod@3.25.76: {}

--- a/sdk/reconnect-signal/pnpm-workspace.yaml
+++ b/sdk/reconnect-signal/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+packages:
+  - "."
+
+onlyBuiltDependencies:
+  - esbuild
+  - sqlite3

--- a/sdk/reconnect-signal/src/index.ts
+++ b/sdk/reconnect-signal/src/index.ts
@@ -1,0 +1,144 @@
+import { Agent } from "@cursor/sdk"
+
+import {
+  createConnectionStateHub,
+  createReconnectAwareIdleTimer,
+  watchStream,
+  type ConnectionStateEvent,
+  type LocalReconnectOptions,
+  type StreamEvent,
+} from "./reconnect.js"
+
+const DEFAULT_IDLE_MS = 5_000
+
+async function main() {
+  const live = process.argv.includes("--live")
+  if (live) {
+    await runLive()
+    return
+  }
+  await runSimulated()
+}
+
+async function runSimulated() {
+  const hub = createConnectionStateHub()
+  const idle = createReconnectAwareIdleTimer({
+    idleMs: DEFAULT_IDLE_MS,
+    isRetrying: () => hub.isRetrying(),
+    onIdle: () => {
+      console.error("idle timeout: model silence (SDK was not reconnecting)")
+      process.exitCode = 2
+    },
+  })
+
+  hub.onConnectionStateChange(logConnection)
+  idle.start()
+
+  const stream = simulatedRun(hub)
+  for await (const event of watchStream(stream, hub)) {
+    logStatus(event)
+    idle.touch()
+  }
+
+  idle.stop()
+}
+
+async function runLive() {
+  const apiKey = process.env.CURSOR_API_KEY
+  if (!apiKey) {
+    throw new Error("Set CURSOR_API_KEY to run --live.")
+  }
+
+  const hub = createConnectionStateHub()
+  const local: LocalReconnectOptions = {
+    enableAgentRetries: true,
+    onConnectionStateChange: (event) => hub.notify(event),
+  }
+  const idle = createReconnectAwareIdleTimer({
+    idleMs: Number(process.env.IDLE_MS ?? DEFAULT_IDLE_MS),
+    isRetrying: () => hub.isRetrying(),
+    onIdle: () => {
+      throw new Error("idle timeout: model silence (SDK was not reconnecting)")
+    },
+  })
+
+  hub.onConnectionStateChange(logConnection)
+
+  await using agent = await Agent.create({
+    apiKey,
+    name: "Reconnect signal example",
+    model: { id: process.env.CURSOR_MODEL ?? "composer-2" },
+    local: {
+      cwd: process.cwd(),
+      ...local,
+    },
+  })
+
+  const run = await agent.send(
+    process.env.CURSOR_PROMPT ?? "Explain this project in one paragraph.",
+  )
+  idle.start()
+
+  for await (const event of watchStream(run.stream() as AsyncIterable<StreamEvent>, hub)) {
+    logStatus(event)
+    if (event.type === "assistant") {
+      process.stdout.write(assistantText(event))
+    }
+    idle.touch()
+  }
+
+  idle.stop()
+  await run.wait()
+}
+
+function logStatus(event: StreamEvent & { message?: unknown }) {
+  if (event.type !== "status") {
+    return
+  }
+  const extra = typeof event.message === "string" ? `: ${event.message}` : ""
+  console.log(`status ${event.status ?? ""}${extra}`)
+}
+
+function logConnection(event: ConnectionStateEvent) {
+  if (event.state === "reconnecting") {
+    console.log(`connection reconnecting (attempt ${event.attempt})`)
+    return
+  }
+  console.log("connection connected")
+}
+
+async function* simulatedRun(hub: ReturnType<typeof createConnectionStateHub>) {
+  yield {
+    type: "status" as const,
+    agent_id: "demo-agent",
+    run_id: "demo-run",
+    status: "RUNNING" as const,
+  }
+  await delay(80)
+  hub.notify({ state: "reconnecting", attempt: 1 })
+  await delay(120)
+  hub.notify({ state: "connected" })
+  yield {
+    type: "status" as const,
+    agent_id: "demo-agent",
+    run_id: "demo-run",
+    status: "FINISHED" as const,
+  }
+}
+
+function assistantText(event: StreamEvent) {
+  const message = (event as { message?: { content?: Array<{ type?: string; text?: string }> } }).message
+  const blocks = Array.isArray(message?.content) ? message.content : []
+  return blocks
+    .filter((block) => block.type === "text" && typeof block.text === "string")
+    .map((block) => block.text)
+    .join("")
+}
+
+function delay(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+await main()

--- a/sdk/reconnect-signal/src/reconnect.test.ts
+++ b/sdk/reconnect-signal/src/reconnect.test.ts
@@ -198,3 +198,38 @@ test("watchStream closes the underlying iterator when the consumer stops early",
 
   assert.equal(closed, true)
 })
+
+test("watchStream cleanup does not hang if the consumer stops during RETRYING", async () => {
+  const hub = createConnectionStateHub()
+  const stream = (async function* () {
+    yield {
+      type: "status" as const,
+      agent_id: "agent-1",
+      run_id: "run-1",
+      status: "RUNNING" as const,
+    }
+    await new Promise(() => {})
+  })()
+
+  const events = watchStream(stream, hub)
+  const first = await events.next()
+  assert.equal(
+    first.value && "status" in first.value ? first.value.status : undefined,
+    "RUNNING",
+  )
+
+  const waiting = events.next()
+  hub.notify({ state: "reconnecting", attempt: 1 })
+  const retrying = await waiting
+  assert.equal(
+    retrying.value && "status" in retrying.value ? retrying.value.status : undefined,
+    "RETRYING",
+  )
+
+  await Promise.race([
+    events.return(),
+    delay(100).then(() => {
+      throw new Error("cleanup hung")
+    }),
+  ])
+})

--- a/sdk/reconnect-signal/src/reconnect.test.ts
+++ b/sdk/reconnect-signal/src/reconnect.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  asRetryingStatus,
+  createConnectionStateHub,
+  createReconnectAwareIdleTimer,
+  watchStream,
+} from "./reconnect.js"
+
+function delay(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+test("hub notifies listeners of reconnecting then connected", () => {
+  const hub = createConnectionStateHub()
+  const events: string[] = []
+  const stop = hub.onConnectionStateChange((event) => {
+    events.push(event.state)
+  })
+
+  assert.equal(hub.getState(), "connected")
+  assert.equal(hub.isRetrying(), false)
+
+  hub.notify({ state: "reconnecting", attempt: 1 })
+  assert.equal(hub.getState(), "reconnecting")
+  assert.equal(hub.isRetrying(), true)
+
+  hub.notify({ state: "connected" })
+  assert.equal(hub.getState(), "connected")
+  assert.equal(hub.isRetrying(), false)
+  assert.deepEqual(events, ["reconnecting", "connected"])
+
+  stop()
+})
+
+test("idle timer fires after silence when the SDK is not retrying", async () => {
+  const hub = createConnectionStateHub()
+  let fired = false
+  const timer = createReconnectAwareIdleTimer({
+    idleMs: 40,
+    isRetrying: () => hub.isRetrying(),
+    onIdle: () => {
+      fired = true
+    },
+  })
+
+  timer.start()
+  await delay(80)
+  timer.stop()
+  assert.equal(fired, true)
+})
+
+test("idle timer does not fire while an SDK reconnect is in progress", async () => {
+  const hub = createConnectionStateHub()
+  let fired = false
+  const timer = createReconnectAwareIdleTimer({
+    idleMs: 40,
+    isRetrying: () => hub.isRetrying(),
+    onIdle: () => {
+      fired = true
+    },
+  })
+
+  timer.start()
+  hub.notify({ state: "reconnecting", attempt: 1 })
+  await delay(90)
+  timer.stop()
+  assert.equal(fired, false)
+})
+
+test("idle timer resumes after reconnect and fires on later silence", async () => {
+  const hub = createConnectionStateHub()
+  let fired = false
+  const timer = createReconnectAwareIdleTimer({
+    idleMs: 40,
+    isRetrying: () => hub.isRetrying(),
+    onIdle: () => {
+      fired = true
+    },
+  })
+
+  timer.start()
+  hub.notify({ state: "reconnecting", attempt: 2 })
+  await delay(50)
+  hub.notify({ state: "connected" })
+  assert.equal(fired, false)
+  await delay(80)
+  timer.stop()
+  assert.equal(fired, true)
+})
+
+test("asRetryingStatus exports a public RETRYING stream status", () => {
+  assert.deepEqual(
+    asRetryingStatus({ agentId: "agent-1", runId: "run-1", attempt: 3 }),
+    {
+      type: "status",
+      agent_id: "agent-1",
+      run_id: "run-1",
+      status: "RETRYING",
+      message: "SDK reconnect attempt 3",
+    },
+  )
+})
+
+test("watchStream yields RETRYING when the hub reports a reconnect", async () => {
+  const hub = createConnectionStateHub()
+  const stream = (async function* () {
+    yield {
+      type: "status" as const,
+      agent_id: "agent-1",
+      run_id: "run-1",
+      status: "RUNNING" as const,
+    }
+    await delay(30)
+    hub.notify({ state: "reconnecting", attempt: 1 })
+    await delay(20)
+    yield {
+      type: "status" as const,
+      agent_id: "agent-1",
+      run_id: "run-1",
+      status: "RUNNING" as const,
+    }
+  })()
+
+  const seen: string[] = []
+  for await (const event of watchStream(stream, hub)) {
+    if (event.type === "status") {
+      seen.push(event.status)
+    }
+  }
+
+  assert.deepEqual(seen, ["RUNNING", "RETRYING", "RUNNING"])
+})

--- a/sdk/reconnect-signal/src/reconnect.test.ts
+++ b/sdk/reconnect-signal/src/reconnect.test.ts
@@ -134,3 +134,67 @@ test("watchStream yields RETRYING when the hub reports a reconnect", async () =>
 
   assert.deepEqual(seen, ["RUNNING", "RETRYING", "RUNNING"])
 })
+
+test("watchStream does not leak an unhandled rejection when reconnect wins and the stream later fails", async () => {
+  const hub = createConnectionStateHub()
+  const leaked: unknown[] = []
+  const onUnhandled = (reason: unknown) => {
+    leaked.push(reason)
+  }
+  process.on("unhandledRejection", onUnhandled)
+
+  try {
+    const stream = (async function* () {
+      yield {
+        type: "status" as const,
+        agent_id: "agent-1",
+        run_id: "run-1",
+        status: "RUNNING" as const,
+      }
+      await delay(20)
+      hub.notify({ state: "reconnecting", attempt: 1 })
+      await delay(20)
+      throw new Error("transport failed")
+    })()
+
+    await assert.rejects(
+      async () => {
+        for await (const event of watchStream(stream, hub)) {
+          void event
+        }
+      },
+      { message: "transport failed" },
+    )
+
+    await delay(30)
+    assert.equal(leaked.length, 0)
+  } finally {
+    process.off("unhandledRejection", onUnhandled)
+  }
+})
+
+test("watchStream closes the underlying iterator when the consumer stops early", async () => {
+  const hub = createConnectionStateHub()
+  let closed = false
+  const stream = (async function* () {
+    try {
+      yield {
+        type: "status" as const,
+        agent_id: "agent-1",
+        run_id: "run-1",
+        status: "RUNNING" as const,
+      }
+      await new Promise(() => {})
+    } finally {
+      closed = true
+    }
+  })()
+
+  for await (const event of watchStream(stream, hub)) {
+    if (event.status === "RUNNING") {
+      break
+    }
+  }
+
+  assert.equal(closed, true)
+})

--- a/sdk/reconnect-signal/src/reconnect.ts
+++ b/sdk/reconnect-signal/src/reconnect.ts
@@ -1,0 +1,229 @@
+export type ConnectionState = "connected" | "reconnecting"
+
+export type ConnectionStateEvent =
+  | { state: "connected" }
+  | { state: "reconnecting"; attempt: number; trigger?: unknown }
+
+export type ConnectionStateListener = (event: ConnectionStateEvent) => void
+
+export type RunStreamStatus =
+  | "CREATING"
+  | "RUNNING"
+  | "RETRYING"
+  | "FINISHED"
+  | "ERROR"
+  | "CANCELLED"
+  | "EXPIRED"
+
+export type RetryingStatusMessage = {
+  type: "status"
+  agent_id: string
+  run_id: string
+  status: "RETRYING"
+  message?: string
+}
+
+export type StreamEvent = {
+  type: string
+  agent_id?: string
+  run_id?: string
+  status?: string
+}
+
+export type ConnectionStateHub = {
+  getState(): ConnectionState
+  isRetrying(): boolean
+  onConnectionStateChange(listener: ConnectionStateListener): () => void
+  notify(event: ConnectionStateEvent): void
+}
+
+export type ReconnectAwareIdleTimer = {
+  start(): void
+  touch(): void
+  stop(): void
+}
+
+/**
+ * Public reconnect/retry signal. `@cursor/sdk` already has this hook internally
+ * (`onConnectionStateChange` with `reconnecting` / `connected`) but does not
+ * export it. Pass `hub.notify` as `local.onConnectionStateChange` so a future
+ * SDK release can forward events without an embedder change.
+ */
+export function createConnectionStateHub(): ConnectionStateHub {
+  let state: ConnectionState = "connected"
+  const listeners = new Set<ConnectionStateListener>()
+
+  return {
+    getState() {
+      return state
+    },
+    isRetrying() {
+      return state === "reconnecting"
+    },
+    onConnectionStateChange(listener) {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+    notify(event) {
+      state = event.state
+      for (const listener of listeners) {
+        listener(event)
+      }
+    },
+  }
+}
+
+export function asRetryingStatus(input: {
+  agentId: string
+  runId: string
+  attempt?: number
+}): RetryingStatusMessage {
+  return {
+    type: "status",
+    agent_id: input.agentId,
+    run_id: input.runId,
+    status: "RETRYING",
+    message:
+      input.attempt === undefined
+        ? "SDK reconnect in progress"
+        : `SDK reconnect attempt ${input.attempt}`,
+  }
+}
+
+/**
+ * Idle watchdog that freezes while the SDK is reconnecting so a stall retry
+ * is not reported as a dead model.
+ */
+export function createReconnectAwareIdleTimer(options: {
+  idleMs: number
+  isRetrying: () => boolean
+  onIdle: () => void
+}): ReconnectAwareIdleTimer {
+  const { idleMs, isRetrying, onIdle } = options
+  let handle: ReturnType<typeof setTimeout> | undefined
+  let stopped = true
+  let remaining = idleMs
+  let lastTick = 0
+
+  const clear = () => {
+    if (handle !== undefined) {
+      clearTimeout(handle)
+      handle = undefined
+    }
+  }
+
+  const arm = () => {
+    clear()
+    if (stopped) {
+      return
+    }
+    handle = setTimeout(tick, Math.max(5, Math.min(remaining, 25)))
+  }
+
+  const tick = () => {
+    if (stopped) {
+      return
+    }
+    const now = Date.now()
+    const elapsed = now - lastTick
+    lastTick = now
+    if (!isRetrying()) {
+      remaining -= elapsed
+      if (remaining <= 0) {
+        onIdle()
+        return
+      }
+    }
+    arm()
+  }
+
+  return {
+    start() {
+      stopped = false
+      remaining = idleMs
+      lastTick = Date.now()
+      arm()
+    },
+    touch() {
+      remaining = idleMs
+      lastTick = Date.now()
+      if (!stopped) {
+        arm()
+      }
+    },
+    stop() {
+      stopped = true
+      clear()
+    },
+  }
+}
+
+export async function* watchStream<T extends StreamEvent>(
+  stream: AsyncIterable<T>,
+  hub: ConnectionStateHub,
+): AsyncGenerator<T | RetryingStatusMessage> {
+  const iterator = stream[Symbol.asyncIterator]()
+  let agentId = ""
+  let runId = ""
+  const pending: Array<T | RetryingStatusMessage> = []
+  let wake: (() => void) | undefined
+
+  const unsub = hub.onConnectionStateChange((event) => {
+    if (event.state !== "reconnecting") {
+      return
+    }
+    pending.push(
+      asRetryingStatus({
+        agentId,
+        runId,
+        attempt: event.attempt,
+      }),
+    )
+    wake?.()
+  })
+
+  try {
+    let next = iterator.next()
+    for (;;) {
+      if (pending.length > 0) {
+        yield pending.shift()!
+        continue
+      }
+
+      const signaled = new Promise<void>((resolve) => {
+        wake = resolve
+      })
+      const winner = await Promise.race([
+        next.then((result) => ({ kind: "message" as const, result })),
+        signaled.then(() => ({ kind: "signal" as const })),
+      ])
+
+      if (winner.kind === "signal") {
+        continue
+      }
+      if (winner.result.done) {
+        break
+      }
+
+      const value = winner.result.value
+      agentId = value.agent_id ?? agentId
+      runId = value.run_id ?? runId
+      yield value
+      next = iterator.next()
+    }
+
+    while (pending.length > 0) {
+      yield pending.shift()!
+    }
+  } finally {
+    unsub()
+  }
+}
+
+/** Extra field `@cursor/sdk` already honors internally but does not type. */
+export type LocalReconnectOptions = {
+  enableAgentRetries?: boolean
+  onConnectionStateChange?: ConnectionStateListener
+}

--- a/sdk/reconnect-signal/src/reconnect.ts
+++ b/sdk/reconnect-signal/src/reconnect.ts
@@ -184,8 +184,14 @@ export async function* watchStream<T extends StreamEvent>(
     wake?.()
   })
 
+  const readNext = () =>
+    iterator.next().then(
+      (result) => ({ kind: "message" as const, result }),
+      (error: unknown) => ({ kind: "error" as const, error }),
+    )
+
   try {
-    let next = iterator.next()
+    let next = readNext()
     for (;;) {
       if (pending.length > 0) {
         yield pending.shift()!
@@ -196,12 +202,15 @@ export async function* watchStream<T extends StreamEvent>(
         wake = resolve
       })
       const winner = await Promise.race([
-        next.then((result) => ({ kind: "message" as const, result })),
+        next,
         signaled.then(() => ({ kind: "signal" as const })),
       ])
 
       if (winner.kind === "signal") {
         continue
+      }
+      if (winner.kind === "error") {
+        throw winner.error
       }
       if (winner.result.done) {
         break
@@ -211,7 +220,7 @@ export async function* watchStream<T extends StreamEvent>(
       agentId = value.agent_id ?? agentId
       runId = value.run_id ?? runId
       yield value
-      next = iterator.next()
+      next = readNext()
     }
 
     while (pending.length > 0) {
@@ -219,6 +228,7 @@ export async function* watchStream<T extends StreamEvent>(
     }
   } finally {
     unsub()
+    await iterator.return?.()
   }
 }
 

--- a/sdk/reconnect-signal/src/reconnect.ts
+++ b/sdk/reconnect-signal/src/reconnect.ts
@@ -184,14 +184,23 @@ export async function* watchStream<T extends StreamEvent>(
     wake?.()
   })
 
-  const readNext = () =>
-    iterator.next().then(
-      (result) => ({ kind: "message" as const, result }),
-      (error: unknown) => ({ kind: "error" as const, error }),
+  let reading = false
+  const readNext = () => {
+    reading = true
+    return iterator.next().then(
+      (result) => {
+        reading = false
+        return { kind: "message" as const, result }
+      },
+      (error: unknown) => {
+        reading = false
+        return { kind: "error" as const, error }
+      },
     )
+  }
 
+  let next = readNext()
   try {
-    let next = readNext()
     for (;;) {
       if (pending.length > 0) {
         yield pending.shift()!
@@ -228,7 +237,12 @@ export async function* watchStream<T extends StreamEvent>(
     }
   } finally {
     unsub()
-    await iterator.return?.()
+    // return() queues behind in-flight next() and hangs on a stalled reconnect.
+    if (reading) {
+      void next.then(() => iterator.return?.())
+    } else {
+      await iterator.return?.()
+    }
   }
 }
 

--- a/sdk/reconnect-signal/tsconfig.json
+++ b/sdk/reconnect-signal/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ESNext"],
+    "types": ["node"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## Summary
- Headless `@cursor/sdk` embedders keep `local.enableAgentRetries: true` so stalled transport can recover, but the SDK does not export reconnect or retry state.
- This example adds a public `onConnectionStateChange` hub (`reconnecting` / `connected`) and a `RETRYING` stream status so an idle timeout can pause during an in-progress SDK reconnect instead of looking like a dead model.
- Closes https://github.com/cursor/cookbook/issues/57

## Test plan
- [ ] `cd sdk/reconnect-signal && pnpm install && pnpm test`
- [ ] `pnpm typecheck`
- [ ] `pnpm dev` prints `RUNNING` → reconnecting → `RETRYING` → connected → `FINISHED`
- [ ] Optional live run: `CURSOR_API_KEY=... pnpm dev -- --live`
