### PR TITLE
Await Agent.create() before using the agent handle

### DIFF
--- a/sdk/app-builder/src/lib/app-builder/server.ts
+++ b/sdk/app-builder/src/lib/app-builder/server.ts
@@ -334,12 +334,15 @@ async function promptProjectNameWithXml(
     }, getProjectNameTimeoutMs())
   })
 
-  const agent = await Agent.create({
-    apiKey,
-    model: { id: process.env.CURSOR_PROJECT_NAME_MODEL ?? "composer-2" },
-  })
-
+  let agent: SDKAgent | undefined
   try {
+    agent = await Promise.race([
+      Agent.create({
+        apiKey,
+        model: { id: process.env.CURSOR_PROJECT_NAME_MODEL ?? "composer-2" },
+      }),
+      timeoutPromise,
+    ])
     const run = await agent.send(buildProjectNamePrompt(context))
 
     return await Promise.race([
@@ -350,7 +353,7 @@ async function promptProjectNameWithXml(
     if (timeout) {
       clearTimeout(timeout)
     }
-    agent.close()
+    agent?.close()
   }
 }
 

--- a/sdk/app-builder/src/lib/app-builder/server.ts
+++ b/sdk/app-builder/src/lib/app-builder/server.ts
@@ -334,7 +334,7 @@ async function promptProjectNameWithXml(
     }, getProjectNameTimeoutMs())
   })
 
-  const agent = Agent.create({
+  const agent = await Agent.create({
     apiKey,
     model: { id: process.env.CURSOR_PROJECT_NAME_MODEL ?? "composer-2" },
   })

--- a/sdk/coding-agent-cli/package.json
+++ b/sdk/coding-agent-cli/package.json
@@ -14,6 +14,7 @@
     "dev": "bun src/index.ts",
     "build": "tsc -p tsconfig.json",
     "start": "bun dist/index.js",
+    "test": "tsx --test src/agent.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
@@ -25,6 +26,7 @@
   "devDependencies": {
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
+    "tsx": "^4.23.13",
     "typescript": "^6.0.3"
   }
 }

--- a/sdk/coding-agent-cli/pnpm-lock.yaml
+++ b/sdk/coding-agent-cli/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
+      tsx:
+        specifier: ^4.23.13
+        version: 4.23.13
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -79,6 +82,162 @@ packages:
 
   '@dimforge/rapier2d-simd-compat@0.17.3':
     resolution: {integrity: sha512-bijvwWz6NHsNj5e5i1vtd3dU2pDhthSaTUZSh14DUGGKJfw8eMnlWZsxwHBxB/a3AXVNDjL9abuHw1k9FGR+jg==}
+
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@fastify/busboy@2.1.1':
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
@@ -437,6 +596,11 @@ packages:
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -468,6 +632,11 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   gauge@4.0.4:
     resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
@@ -881,6 +1050,11 @@ packages:
     resolution: {integrity: sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==}
     engines: {node: '>=10'}
 
+  tsx@4.23.13:
+    resolution: {integrity: sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
@@ -1018,6 +1192,84 @@ snapshots:
       - supports-color
 
   '@dimforge/rapier2d-simd-compat@0.17.3':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
     optional: true
 
   '@fastify/busboy@2.1.1': {}
@@ -1481,6 +1733,35 @@ snapshots:
   err-code@2.0.3:
     optional: true
 
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
+
   event-target-shim@5.0.1: {}
 
   events@3.3.0: {}
@@ -1504,6 +1785,9 @@ snapshots:
       minipass: 3.3.6
 
   fs.realpath@1.0.0:
+    optional: true
+
+  fsevents@2.3.3:
     optional: true
 
   gauge@4.0.4:
@@ -2023,6 +2307,12 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
+
+  tsx@4.23.13:
+    dependencies:
+      esbuild: 0.28.2
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tunnel-agent@0.6.0:
     dependencies:

--- a/sdk/coding-agent-cli/src/agent.test.ts
+++ b/sdk/coding-agent-cli/src/agent.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { disposeCreatedAgent, settledAgent } from "./agent.js"
+
+test("settledAgent returns a resolved handle", async () => {
+  const value = await settledAgent("ready", () => {
+    throw new Error("should not recreate")
+  })
+  assert.equal(value, "ready")
+})
+
+test("settledAgent recreates after a rejected create", async () => {
+  let created = 0
+  const value = await settledAgent(Promise.reject(new Error("create failed")), () => {
+    created += 1
+    return "recovered"
+  })
+  assert.equal(value, "recovered")
+  assert.equal(created, 1)
+})
+
+test("settledAgent does not swallow a failed recreate", async () => {
+  await assert.rejects(
+    () =>
+      settledAgent(Promise.reject(new Error("create failed")), () => {
+        throw new Error("still failing")
+      }),
+    /still failing/
+  )
+})
+
+test("disposeCreatedAgent ignores a rejected create", async () => {
+  await disposeCreatedAgent(Promise.reject(new Error("create failed")))
+})

--- a/sdk/coding-agent-cli/src/agent.ts
+++ b/sdk/coding-agent-cli/src/agent.ts
@@ -67,7 +67,7 @@ const AGENT_INSTRUCTIONS = [
 ].join("\n")
 
 export class CodingAgentSession {
-  private agent: SDKAgent
+  private agent: SDKAgent | Promise<SDKAgent>
   private agentKey: string
   private cloudRepository: CloudRepository | null = null
   private currentRun: Run | null = null
@@ -141,7 +141,7 @@ export class CodingAgentSession {
   }
 
   async dispose() {
-    await this.agent[Symbol.asyncDispose]()
+    await (await this.agent)[Symbol.asyncDispose]()
   }
 
   async cancelCurrentRun(): Promise<CancelRunResult> {
@@ -165,7 +165,7 @@ export class CodingAgentSession {
   async sendPrompt({ prompt, onEvent }: SendPromptOptions) {
     await this.ensureAgentFresh()
 
-    const run = await this.agent.send(buildPrompt(prompt), {
+    const run = await (await this.agent).send(buildPrompt(prompt), {
       ...(this.mode === "local" ? { model: this.modelSelection } : {}),
       ...(this.mode === "local" && this.force ? { local: { force: true } } : {}),
     })
@@ -231,7 +231,7 @@ export class CodingAgentSession {
     const previousAgent = this.agent
     this.agent = this.createAgent()
     this.agentKey = this.currentAgentKey()
-    await previousAgent[Symbol.asyncDispose]()
+    await (await previousAgent)[Symbol.asyncDispose]()
   }
 
   private currentAgentKey() {

--- a/sdk/coding-agent-cli/src/agent.ts
+++ b/sdk/coding-agent-cli/src/agent.ts
@@ -66,6 +66,27 @@ const AGENT_INSTRUCTIONS = [
   "Keep progress updates concise and summarize the result clearly.",
 ].join("\n")
 
+export async function settledAgent<T>(
+  current: T | Promise<T>,
+  recreate: () => T | Promise<T>
+): Promise<T> {
+  try {
+    return await current
+  } catch {
+    return await recreate()
+  }
+}
+
+export async function disposeCreatedAgent(
+  agent: SDKAgent | Promise<SDKAgent>
+): Promise<void> {
+  try {
+    await (await agent)[Symbol.asyncDispose]()
+  } catch {
+    // Failed creates have nothing to dispose.
+  }
+}
+
 export class CodingAgentSession {
   private agent: SDKAgent | Promise<SDKAgent>
   private agentKey: string
@@ -141,7 +162,7 @@ export class CodingAgentSession {
   }
 
   async dispose() {
-    await (await this.agent)[Symbol.asyncDispose]()
+    await disposeCreatedAgent(this.agent)
   }
 
   async cancelCurrentRun(): Promise<CancelRunResult> {
@@ -165,7 +186,7 @@ export class CodingAgentSession {
   async sendPrompt({ prompt, onEvent }: SendPromptOptions) {
     await this.ensureAgentFresh()
 
-    const run = await (await this.agent).send(buildPrompt(prompt), {
+    const run = await (await this.resolvedAgent()).send(buildPrompt(prompt), {
       ...(this.mode === "local" ? { model: this.modelSelection } : {}),
       ...(this.mode === "local" && this.force ? { local: { force: true } } : {}),
     })
@@ -221,6 +242,13 @@ export class CodingAgentSession {
     })
   }
 
+  private async resolvedAgent() {
+    const agent = await settledAgent(this.agent, () => this.createAgent())
+    this.agent = agent
+    this.agentKey = this.currentAgentKey()
+    return agent
+  }
+
   private async ensureAgentFresh() {
     if (this.agentKey !== this.currentAgentKey()) {
       await this.replaceAgent()
@@ -229,9 +257,9 @@ export class CodingAgentSession {
 
   private async replaceAgent() {
     const previousAgent = this.agent
-    this.agent = this.createAgent()
+    this.agent = await this.createAgent()
     this.agentKey = this.currentAgentKey()
-    await (await previousAgent)[Symbol.asyncDispose]()
+    await disposeCreatedAgent(previousAgent)
   }
 
   private currentAgentKey() {


### PR DESCRIPTION
## Summary

- `Agent.create()` may return a `Promise<SDKAgent>`. Two examples used the value as a handle immediately.
- Coding Agent CLI now awaits the create promise before `send` and dispose.
- App Builder project-name generation awaits `Agent.create()` before `send` / `close`.

Fixes #60

## Test plan

- [x] `cd sdk/coding-agent-cli && pnpm typecheck`
- [x] `cd sdk/app-builder && pnpm exec tsc -p tsconfig.json --noEmit`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent lifecycle and error handling on prompt/dispose paths; incorrect awaiting could break CLI sessions or project naming, but scope is limited and covered by new unit tests.
> 
> **Overview**
> Treats **`Agent.create()`** as async-capable (`SDKAgent | Promise<SDKAgent>`) in the coding agent CLI and app-builder project-name flow, so **`send`**, **dispose**, and **close** only run on a settled handle.
> 
> In **coding-agent-cli**, **`settledAgent`** and **`disposeCreatedAgent`** centralize awaiting or recovering from failed creates and safe teardown; **`CodingAgentSession`** resolves the agent before prompts and uses optional close on timeout paths. Adds **`pnpm test`** with **`tsx`** and unit tests for those helpers.
> 
> In **app-builder**, project-name generation **`Promise.race`s** **`Agent.create()`** against the existing timeout (same as the run collection) and uses **`agent?.close()`** in **`finally`** when create never completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5555e40ac2b30e1dfc6e6bf483821e9f40d52001. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->