### PR TITLE
Remove unsupported local.envVars from App Builder

### DIFF
--- a/sdk/app-builder/src/lib/app-builder/server.ts
+++ b/sdk/app-builder/src/lib/app-builder/server.ts
@@ -1004,9 +1004,6 @@ async function getOrCreateAgent(session: BuilderSession) {
     model: { id: process.env.CURSOR_MODEL ?? "composer-2" },
     local: {
       cwd: session.projectPath,
-      envVars: {
-        BROWSER: "none",
-      },
     },
   })
 


### PR DESCRIPTION
## Summary

- App Builder passed `local.envVars: { BROWSER: "none" }` into `Agent.create()`.
- `envVars` is cloud-only, so the SDK dropped it and the example taught an invalid option.
- The preview host already sets `BROWSER=none` on the Vite spawn. This change removes the no-op field.

Fixes #61

## Test plan

- [x] `cd sdk/app-builder && pnpm exec tsc -p tsconfig.json --noEmit`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/cleanup only—removes a no-op SDK option with no change to preview or agent runtime behavior.
> 
> **Overview**
> Stops passing **`local.envVars: { BROWSER: "none" }`** when App Builder creates the coding agent. That option is **cloud-only**, so the SDK ignored it and the sample config was misleading.
> 
> Preview behavior is unchanged: **`startDevServer`** still sets **`BROWSER=none`** on the Vite child process. The agent **`local`** block now only sets **`cwd`** to the session project path.
> 
> Fixes #61.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83738c1225900a8ea2429b7d87dfcb34b8b51405. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->