### PR TITLE
[Content] Grok voice-to-voice patient intake agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,8 @@ Learn more in the [Cursor SDK TypeScript docs](https://cursor.com/docs/sdk/types
 
 An educational Python coding-agent loop that uses an xAI Console API key,
 defaults to `grok-4.6`, and provides workspace-scoped file and shell tools.
+
+### [Grok Voice Patient Intake](voice-agents/grok-patient-intake)
+
+A LiveKit voice agent that uses xAI's native realtime speech-to-speech model
+for a fictional family-medicine intake and appointment workflow.

--- a/voice-agents/grok-patient-intake/.env.example
+++ b/voice-agents/grok-patient-intake/.env.example
@@ -1,0 +1,8 @@
+LIVEKIT_URL=
+LIVEKIT_API_KEY=
+LIVEKIT_API_SECRET=
+XAI_API_KEY=
+
+# Optional overrides
+XAI_VOICE_MODEL=grok-voice-latest
+XAI_VOICE=Ara

--- a/voice-agents/grok-patient-intake/.gitignore
+++ b/voice-agents/grok-patient-intake/.gitignore
@@ -1,0 +1,7 @@
+.env
+.env.local
+.venv/
+__pycache__/
+*.egg-info/
+.pytest_cache/
+.ruff_cache/

--- a/voice-agents/grok-patient-intake/README.md
+++ b/voice-agents/grok-patient-intake/README.md
@@ -18,6 +18,7 @@ AgentSession(
         model="grok-voice-latest",
         voice="Ara",
     ),
+    vad=None,
 )
 ```
 
@@ -27,7 +28,8 @@ STT → LLM → TTS cascade, VAD plugin, or turn detector in this example.
 
 > The clinic and every patient are fake, in-memory teaching data. This is not a
 > medical device, a source of medical advice, a production scheduling system,
-> or a HIPAA-ready application. Never enter real patient information.
+> or a HIPAA-ready application. Never enter real patient information. The
+> agent repeats this fake-data warning at the start of each call.
 
 ## Getting Started
 
@@ -53,6 +55,11 @@ Fill in:
 - `LIVEKIT_URL`, `LIVEKIT_API_KEY`, and `LIVEKIT_API_SECRET` from a
   [LiveKit Cloud project](https://cloud.livekit.io/).
 - `XAI_API_KEY` from the [xAI Console](https://console.x.ai/).
+
+LiveKit transports the call and xAI processes its audio, transcript, prompt,
+and tool context. This worker does not start a recording, but recording can be
+enabled elsewhere in a LiveKit deployment. Review both providers' current data
+handling and retention settings before adapting the example.
 
 Talk to the agent directly from the terminal:
 
@@ -138,4 +145,5 @@ deduplication, intake storage, insurance updates, and emergency recording.
 A real deployment needs authenticated patient access, consent and disclosure,
 encrypted durable storage, EHR integration, audit logging, retention controls,
 human escalation, regional emergency behavior, monitoring, and clinical/legal
-review. Prompts alone do not provide those guarantees.
+review. It must also prevent room recording unless recording is explicitly
+authorized and governed. Prompts alone do not provide those guarantees.

--- a/voice-agents/grok-patient-intake/README.md
+++ b/voice-agents/grok-patient-intake/README.md
@@ -1,0 +1,141 @@
+# Grok Voice Patient Intake
+
+A fictional family-medicine front desk built with
+[LiveKit Agents](https://docs.livekit.io/agents/) and the
+[xAI Grok Voice Agent API](https://docs.x.ai/developers/model-capabilities/audio/speech-to-speech).
+The agent can answer practice questions, find and manage appointments, route
+messages, update insurance, collect pre-visit answers, and escalate possible
+emergencies.
+
+This example reimplements the workflow of LiveKit's
+[xAI patient-intake demo](https://github.com/livekit-examples/python-agents-examples/tree/main/complex-agents/xai-patient-intake),
+but replaces its separately configured speech-to-text, language, and
+text-to-speech models with one native speech-to-speech connection:
+
+```python
+AgentSession(
+    llm=xai.realtime.RealtimeModel(
+        model="grok-voice-latest",
+        voice="Ara",
+    ),
+)
+```
+
+Grok listens to the caller's audio, reasons over the conversation, calls the
+local clinic tools, and speaks the response. There is no separately assembled
+STT → LLM → TTS cascade, VAD plugin, or turn detector in this example.
+
+> The clinic and every patient are fake, in-memory teaching data. This is not a
+> medical device, a source of medical advice, a production scheduling system,
+> or a HIPAA-ready application. Never enter real patient information.
+
+## Getting Started
+
+Use Python 3.10 through 3.14.
+
+Create a virtual environment and install the worker:
+
+```bash
+cd voice-agents/grok-patient-intake
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -e ".[dev]"
+```
+
+Create `.env.local`:
+
+```bash
+cp .env.example .env.local
+```
+
+Fill in:
+
+- `LIVEKIT_URL`, `LIVEKIT_API_KEY`, and `LIVEKIT_API_SECRET` from a
+  [LiveKit Cloud project](https://cloud.livekit.io/).
+- `XAI_API_KEY` from the [xAI Console](https://console.x.ai/).
+
+Talk to the agent directly from the terminal:
+
+```bash
+python src/agent.py console
+```
+
+Or register the worker with LiveKit:
+
+```bash
+python src/agent.py dev
+```
+
+Then connect with the [LiveKit Agents Playground](https://agents-playground.livekit.io/)
+or another LiveKit client that dispatches the agent named
+`grok-patient-intake`. This focused cookbook port does not include the
+upstream demo's custom Next.js frontend.
+
+## Try the fake clinic
+
+The seeded records are recreated for every call:
+
+- Established adult: Jamie Example, born April 12, 1987.
+- Established child: Riley Example, born September 3, 2018.
+- New patients can use any obviously fake identity and phone number.
+
+Example requests:
+
+- “What are your office hours?”
+- “I need to move my existing appointment.”
+- “I am a new patient and need an appointment.”
+- “I need a refill message for the nurse.”
+- “I want to complete my pre-visit questions.”
+
+## Tool surface
+
+`src/agent.py` exposes eight typed tools:
+
+| Tool | Purpose |
+| --- | --- |
+| `read_practice_information` | Read the fictional practice policy |
+| `find_open_times` | Find suitable real slots in the in-memory clinic |
+| `book_appointment` | Register a new patient when needed and book a chosen slot |
+| `manage_appointment` | List, cancel, or reschedule an appointment |
+| `take_message` | Route a refill, results, billing, referral, records, or nurse request |
+| `update_insurance` | Save details from a fictional current insurance card |
+| `record_previsit_intake` | Save a completed set of caller-provided intake answers |
+| `record_emergency_escalation` | Record a possible emergency before urgent direction |
+
+`src/clinic.py` contains the deterministic in-memory records. Tool calls mutate
+only that per-call object; nothing is persisted or sent to an EHR.
+
+## Voice configuration
+
+The defaults follow the current xAI realtime recommendation:
+
+| Environment variable | Default | Purpose |
+| --- | --- | --- |
+| `XAI_VOICE_MODEL` | `grok-voice-latest` | Tracks xAI's recommended realtime voice model |
+| `XAI_VOICE` | `Ara` | Warm, friendly built-in voice |
+
+The LiveKit xAI plugin supplies server-side voice activity detection and turn
+handling. See the
+[LiveKit xAI realtime guide](https://docs.livekit.io/agents/models/realtime/plugins/xai/)
+for supported voices and lower-level options.
+
+## Offline tests
+
+The tests do not connect to LiveKit or xAI and do not consume API credits:
+
+```bash
+pytest
+ruff check .
+ruff format --check .
+```
+
+They verify the direct realtime composition, the exact eight-tool surface, fake
+patient lookup, appointment state changes, new-patient eligibility, message
+deduplication, intake storage, insurance updates, and emergency recording.
+
+## Production safety
+
+A real deployment needs authenticated patient access, consent and disclosure,
+encrypted durable storage, EHR integration, audit logging, retention controls,
+human escalation, regional emergency behavior, monitoring, and clinical/legal
+review. Prompts alone do not provide those guarantees.

--- a/voice-agents/grok-patient-intake/README.md
+++ b/voice-agents/grok-patient-intake/README.md
@@ -8,7 +8,7 @@ messages, update insurance, collect pre-visit answers, and escalate possible
 emergencies.
 
 This example reimplements the workflow of LiveKit's
-[xAI patient-intake demo](https://github.com/livekit-examples/python-agents-examples/tree/main/complex-agents/xai-patient-intake),
+[xAI patient-intake demo](https://github.com/livekit-examples/python-agents-examples/tree/ab7ab31150ea562e4bb8416da1e3df4f6e0e7e8b/complex-agents/xai-patient-intake),
 but replaces its separately configured speech-to-text, language, and
 text-to-speech models with one native speech-to-speech connection:
 
@@ -19,6 +19,7 @@ AgentSession(
         voice="Ara",
     ),
     vad=None,
+    turn_handling=TurnHandlingOptions(turn_detection="realtime_llm"),
 )
 ```
 
@@ -122,7 +123,12 @@ The defaults follow the current xAI realtime recommendation:
 | `XAI_VOICE` | `Ara` | Warm, friendly built-in voice |
 
 The LiveKit xAI plugin supplies server-side voice activity detection and turn
-handling. See the
+handling; `realtime_llm` makes that ownership explicit. Its current default
+ends a turn after 200 ms of silence, so production intake agents should test
+and tune the realtime model's `turn_detection` settings for callers who pause
+while recalling dates, medications, or symptoms. `grok-voice-latest` is a
+floating alias; pin a versioned voice model when release-to-release stability
+is more important than automatically receiving the newest model. See the
 [LiveKit xAI realtime guide](https://docs.livekit.io/agents/models/realtime/plugins/xai/)
 for supported voices and lower-level options.
 

--- a/voice-agents/grok-patient-intake/pyproject.toml
+++ b/voice-agents/grok-patient-intake/pyproject.toml
@@ -1,0 +1,38 @@
+[build-system]
+requires = ["setuptools>=80"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "grok-voice-patient-intake"
+version = "0.1.0"
+description = "A LiveKit patient-intake agent using the xAI realtime voice API"
+requires-python = ">=3.10,<3.15"
+dependencies = [
+  "livekit-agents==1.7.1",
+  "livekit-plugins-xai==1.7.1",
+  "python-dotenv==1.2.3",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest==9.1.1",
+  "pytest-asyncio==1.4.0",
+  "ruff==0.16.5",
+]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["A", "B", "E", "F", "I", "N", "RUF", "SIM", "UP", "W"]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+py-modules = ["agent", "clinic"]

--- a/voice-agents/grok-patient-intake/src/agent.py
+++ b/voice-agents/grok-patient-intake/src/agent.py
@@ -14,6 +14,7 @@ from livekit.agents import (
     AgentSession,
     JobContext,
     ToolError,
+    TurnHandlingOptions,
     cli,
     function_tool,
 )
@@ -417,6 +418,7 @@ def create_session(clinic: Clinic) -> AgentSession[CallState]:
         userdata=CallState(clinic=clinic),
         llm=create_realtime_model(),
         vad=None,
+        turn_handling=TurnHandlingOptions(turn_detection="realtime_llm"),
         max_tool_steps=8,
     )
 

--- a/voice-agents/grok-patient-intake/src/agent.py
+++ b/voice-agents/grok-patient-intake/src/agent.py
@@ -1,0 +1,411 @@
+"""Run a Grok speech-to-speech patient-intake agent with LiveKit."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import date, datetime
+
+from dotenv import load_dotenv
+from livekit.agents import (
+    Agent,
+    AgentServer,
+    AgentSession,
+    JobContext,
+    ToolError,
+    cli,
+    function_tool,
+)
+from livekit.plugins import xai
+
+from clinic import (
+    AppointmentAction,
+    Clinic,
+    ClinicError,
+    MessageKind,
+    Patient,
+    VisitType,
+    create_demo_clinic,
+)
+
+AGENT_NAME = "grok-patient-intake"
+DEFAULT_VOICE_MODEL = "grok-voice-latest"
+DEFAULT_VOICE = "Ara"
+
+PRACTICE_INFORMATION = """
+Maplewood Family Medicine is a fictional teaching clinic at 100 Demo Avenue.
+The office is open Monday through Friday from 8:30 AM to 5:00 PM and is closed
+on weekends. Routine refill requests are reviewed within two business days.
+Only a clinician may interpret test results or give medical advice. Billing,
+records, referrals, and nurse questions can be routed as messages. For a
+life-threatening emergency, callers must call 911; for an immediate mental
+health crisis in the United States, callers should call or text 988.
+""".strip()
+
+BASE_INSTRUCTIONS = """
+You are the automated patient-intake assistant for Maplewood Family Medicine,
+a fictional clinic used only for this software demo. You are not a clinician.
+
+Voice style:
+- Sound warm, calm, and concise. Use one or two short sentences at a time.
+- Ask one question at a time and wait for the answer.
+- Speak naturally without markdown, bullets, code, IDs, or tool names.
+- Do not repeat sensitive details such as a date of birth unless correction is needed.
+
+Workflow:
+- Retain facts the caller has already supplied and never invent missing values.
+- Use a tool for every clinic fact lookup or state change.
+- Never claim that an appointment, message, insurance update, or intake was saved
+  unless the corresponding tool succeeded.
+- Before appointment searches, learn whether the patient is new or established,
+  their first and last name, and date of birth.
+- Offer only appointment times returned by find_open_times. Keep slot and
+  appointment IDs private, and pass the chosen IDs only to tools.
+- Collect pre-visit answers one at a time. Do not diagnose or reinterpret them.
+- Do not give medical advice, approve refills, interpret results, or quote prices.
+
+Safety:
+- If the caller describes a possible emergency, call record_emergency_escalation
+  immediately and stop ordinary intake.
+- For a medical emergency, direct them to call 911 now and not drive themselves.
+- For imminent self-harm or harm to others in the United States, direct them to
+  call or text 988 now, and call 911 if anyone is in immediate danger.
+- Ordinary symptoms without emergency warning signs should be handled as an
+  appointment or nurse message, not an emergency.
+""".strip()
+
+GREETING_INSTRUCTIONS = (
+    "In one short sentence, identify yourself as Maplewood Family Medicine's "
+    "automated assistant and ask how you can help."
+)
+
+
+def _parse_date(value: str, field_name: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except ValueError as error:
+        raise ToolError(f"{field_name} must be a real date in YYYY-MM-DD format.") from error
+
+
+def _format_time(value: datetime) -> str:
+    hour = value.hour % 12 or 12
+    return f"{value:%A, %B} {value.day} at {hour}:{value:%M %p}"
+
+
+@dataclass(slots=True)
+class CallState:
+    clinic: Clinic
+
+
+class PatientIntakeAgent(Agent):
+    """One conversational agent with a fixed, auditable clinic tool surface."""
+
+    def __init__(self, clinic: Clinic, *, greet: bool = True) -> None:
+        super().__init__(instructions=BASE_INSTRUCTIONS)
+        self.clinic = clinic
+        self.greet = greet
+        self._new_patient_searches: set[tuple[str, date]] = set()
+
+    async def on_enter(self) -> None:
+        if self.greet:
+            self.session.generate_reply(instructions=GREETING_INSTRUCTIONS)
+
+    def _patient(self, last_name: str, date_of_birth: str) -> Patient:
+        try:
+            return self.clinic.find_patient(
+                last_name,
+                _parse_date(date_of_birth, "date_of_birth"),
+            )
+        except ClinicError as error:
+            raise ToolError(
+                "No patient matched that last name and date of birth. Ask the caller "
+                "to check both details once; do not guess."
+            ) from error
+
+    @function_tool
+    async def read_practice_information(self) -> str:
+        """Read the complete fictional practice guide before answering policy questions."""
+        return PRACTICE_INFORMATION
+
+    @function_tool
+    async def find_open_times(
+        self,
+        patient_status: str,
+        last_name: str,
+        date_of_birth: str,
+        provider_id: str = "",
+        preferred_date: str = "",
+    ) -> str:
+        """Find suitable appointment openings for a caller.
+
+        Args:
+            patient_status: Either new or established, based on what the caller said.
+            last_name: Patient's actual surname.
+            date_of_birth: Full date of birth in YYYY-MM-DD format.
+            provider_id: Optional provider ID: rivera, patel, or nguyen.
+            preferred_date: Optional exact date in YYYY-MM-DD format.
+        """
+        born = _parse_date(date_of_birth, "date_of_birth")
+        if patient_status not in {"new", "established"}:
+            raise ToolError("patient_status must be new or established.")
+
+        if patient_status == "established":
+            patient = self._patient(last_name, date_of_birth)
+        else:
+            try:
+                patient = self.clinic.find_patient(last_name, born)
+            except ClinicError:
+                patient = Patient(
+                    chart_id="pending",
+                    first_name="pending",
+                    last_name=last_name,
+                    date_of_birth=born,
+                    phone="pending",
+                    registered_during_call=True,
+                )
+                self._new_patient_searches.add((last_name.strip().casefold(), born))
+
+        on_date = _parse_date(preferred_date, "preferred_date") if preferred_date else None
+        try:
+            slots = self.clinic.open_slots(
+                patient=patient,
+                provider_id=provider_id or None,
+                preferred_date=on_date,
+            )
+        except ClinicError as error:
+            raise ToolError(str(error)) from error
+
+        if not slots:
+            return "No suitable appointment times are available for that request."
+        return "Available times:\n" + "\n".join(
+            f"{slot.id}: {_format_time(slot.start)} with "
+            f"{self.clinic.providers[slot.provider_id].name}"
+            for slot in slots[:3]
+        )
+
+    @function_tool
+    async def book_appointment(
+        self,
+        patient_status: str,
+        first_name: str,
+        last_name: str,
+        date_of_birth: str,
+        phone: str,
+        slot_id: str,
+        visit_type: VisitType,
+        reason: str,
+    ) -> str:
+        """Book a time returned by find_open_times.
+
+        Args:
+            patient_status: Either new or established.
+            first_name: Patient's first name.
+            last_name: Patient's surname.
+            date_of_birth: Full date of birth in YYYY-MM-DD format.
+            phone: Callback phone. Required for a new patient.
+            slot_id: Private slot ID returned by find_open_times.
+            visit_type: new_problem, annual_physical, well_child, follow_up, or telehealth.
+            reason: Brief caller-described reason without diagnosis.
+        """
+        born = _parse_date(date_of_birth, "date_of_birth")
+        try:
+            patient = self.clinic.find_patient(last_name, born)
+        except ClinicError:
+            if patient_status != "new":
+                raise ToolError(
+                    "No established patient matched those details. Check them before booking."
+                ) from None
+            if (last_name.strip().casefold(), born) not in self._new_patient_searches:
+                raise ToolError("Call find_open_times with these patient details before booking.")
+            try:
+                patient = self.clinic.register_patient(
+                    first_name=first_name,
+                    last_name=last_name,
+                    date_of_birth=born,
+                    phone=phone,
+                )
+            except ClinicError as error:
+                raise ToolError(str(error)) from error
+
+        try:
+            appointment = self.clinic.book(
+                patient=patient,
+                slot_id=slot_id,
+                visit_type=visit_type,
+                reason=reason,
+            )
+        except ClinicError as error:
+            raise ToolError(str(error)) from error
+        provider = self.clinic.providers[appointment.provider_id]
+        return f"Booked {_format_time(appointment.start)} with {provider.name}."
+
+    @function_tool
+    async def manage_appointment(
+        self,
+        action: AppointmentAction,
+        last_name: str,
+        date_of_birth: str,
+        appointment_id: str = "",
+        new_slot_id: str = "",
+    ) -> str:
+        """List, cancel, or reschedule an established patient's appointments.
+
+        Args:
+            action: list, cancel, or reschedule.
+            last_name: Patient's surname.
+            date_of_birth: Full date of birth in YYYY-MM-DD format.
+            appointment_id: Private appointment ID for cancel or reschedule.
+            new_slot_id: Private slot ID from find_open_times for reschedule.
+        """
+        patient = self._patient(last_name, date_of_birth)
+        if action == "list":
+            appointments = self.clinic.scheduled_appointments(patient)
+            if not appointments:
+                return "No upcoming appointments are scheduled."
+            return "Upcoming appointments:\n" + "\n".join(
+                f"{appointment.id}: {_format_time(appointment.start)} with "
+                f"{self.clinic.providers[appointment.provider_id].name}"
+                for appointment in appointments
+            )
+
+        if not appointment_id:
+            raise ToolError("appointment_id is required after listing appointments.")
+        try:
+            if action == "cancel":
+                appointment = self.clinic.cancel(
+                    patient=patient,
+                    appointment_id=appointment_id,
+                )
+                return f"Cancelled the appointment on {_format_time(appointment.start)}."
+            if action != "reschedule":
+                raise ToolError("action must be list, cancel, or reschedule.")
+            if not new_slot_id:
+                raise ToolError("new_slot_id is required after finding a new time.")
+            appointment = self.clinic.reschedule(
+                patient=patient,
+                appointment_id=appointment_id,
+                new_slot_id=new_slot_id,
+            )
+        except ClinicError as error:
+            raise ToolError(str(error)) from error
+        provider = self.clinic.providers[appointment.provider_id]
+        return f"Rescheduled to {_format_time(appointment.start)} with {provider.name}."
+
+    @function_tool
+    async def take_message(
+        self,
+        last_name: str,
+        date_of_birth: str,
+        kind: MessageKind,
+        summary: str,
+        callback_phone: str = "",
+    ) -> str:
+        """Route a refill, results, billing, referral, records, or nurse request.
+
+        Args:
+            last_name: Patient's surname.
+            date_of_birth: Full date of birth in YYYY-MM-DD format.
+            kind: Destination queue for the message.
+            summary: Brief factual request in the caller's own terms.
+            callback_phone: Caller-supplied callback phone, or empty to use the chart.
+        """
+        patient = self._patient(last_name, date_of_birth)
+        before = len(self.clinic.messages)
+        message = self.clinic.take_message(
+            patient=patient,
+            kind=kind,
+            summary=summary,
+            callback_phone=callback_phone,
+        )
+        if len(self.clinic.messages) == before:
+            return f"A {message.kind.replace('_', ' ')} message is already pending."
+        return f"Routed the {message.kind.replace('_', ' ')} request."
+
+    @function_tool
+    async def update_insurance(
+        self,
+        last_name: str,
+        date_of_birth: str,
+        carrier: str,
+        member_id: str,
+        group_number: str = "",
+    ) -> str:
+        """Save insurance details read from an established patient's current card."""
+        patient = self._patient(last_name, date_of_birth)
+        try:
+            insurance = self.clinic.update_insurance(
+                patient=patient,
+                carrier=carrier,
+                member_id=member_id,
+                group_number=group_number,
+            )
+        except ClinicError as error:
+            raise ToolError(str(error)) from error
+        return f"Updated the insurance to {insurance.carrier}."
+
+    @function_tool
+    async def record_previsit_intake(
+        self,
+        last_name: str,
+        date_of_birth: str,
+        chief_complaint: str,
+        symptom_duration: str,
+        medications: list[str],
+        allergies: list[str],
+        conditions: list[str],
+        pharmacy: str,
+    ) -> str:
+        """Save a complete set of caller-provided pre-visit answers."""
+        patient = self._patient(last_name, date_of_birth)
+        self.clinic.record_intake(
+            patient=patient,
+            chief_complaint=chief_complaint,
+            symptom_duration=symptom_duration,
+            medications=medications,
+            allergies=allergies,
+            conditions=conditions,
+            pharmacy=pharmacy,
+        )
+        return "Saved the pre-visit answers."
+
+    @function_tool
+    async def record_emergency_escalation(self, reported_symptoms: str) -> str:
+        """Record a possible emergency before giving the required 911 or 988 direction."""
+        self.clinic.record_emergency(reported_symptoms)
+        return "Emergency escalation recorded. Give the appropriate direction and stop intake."
+
+
+def create_realtime_model() -> xai.realtime.RealtimeModel:
+    """Create the single speech-to-speech model used for listening and speaking."""
+    return xai.realtime.RealtimeModel(
+        model=os.getenv("XAI_VOICE_MODEL", DEFAULT_VOICE_MODEL),
+        voice=os.getenv("XAI_VOICE", DEFAULT_VOICE),
+    )
+
+
+def create_session(clinic: Clinic) -> AgentSession[CallState]:
+    """Compose LiveKit around one native xAI realtime model, with no cascade."""
+    return AgentSession[CallState](
+        userdata=CallState(clinic=clinic),
+        llm=create_realtime_model(),
+        max_tool_steps=8,
+    )
+
+
+server = AgentServer()
+
+
+@server.rtc_session(agent_name=AGENT_NAME)
+async def patient_intake(ctx: JobContext) -> None:
+    clinic = create_demo_clinic(datetime.now())
+    session = create_session(clinic)
+    await session.start(
+        agent=PatientIntakeAgent(clinic),
+        room=ctx.room,
+    )
+    await ctx.connect()
+
+
+if __name__ == "__main__":
+    load_dotenv(".env.local")
+    cli.run_app(server)

--- a/voice-agents/grok-patient-intake/src/agent.py
+++ b/voice-agents/grok-patient-intake/src/agent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from datetime import date, datetime
+from typing import Literal
 
 from dotenv import load_dotenv
 from livekit.agents import (
@@ -31,6 +32,8 @@ from clinic import (
 AGENT_NAME = "grok-patient-intake"
 DEFAULT_VOICE_MODEL = "grok-voice-latest"
 DEFAULT_VOICE = "Ara"
+PatientStatus = Literal["new", "established"]
+CallerRelationship = Literal["patient", "parent_or_guardian", "other"]
 
 PRACTICE_INFORMATION = """
 Maplewood Family Medicine is a fictional teaching clinic at 100 Demo Avenue.
@@ -54,6 +57,7 @@ Voice style:
 
 Workflow:
 - Retain facts the caller has already supplied and never invent missing values.
+- Remind callers this is a fake-data demo if they try to share real information.
 - Use a tool for every clinic fact lookup or state change.
 - Never claim that an appointment, message, insurance update, or intake was saved
   unless the corresponding tool succeeded.
@@ -63,6 +67,8 @@ Workflow:
   appointment IDs private, and pass the chosen IDs only to tools.
 - Collect pre-visit answers one at a time. Do not diagnose or reinterpret them.
 - Do not give medical advice, approve refills, interpret results, or quote prices.
+- Do not reveal appointment details to an unrelated caller. A parent or guardian
+  may access only a child patient's appointment information in this demo.
 
 Safety:
 - If the caller describes a possible emergency, call record_emergency_escalation
@@ -74,9 +80,9 @@ Safety:
   appointment or nurse message, not an emergency.
 """.strip()
 
-GREETING_INSTRUCTIONS = (
-    "In one short sentence, identify yourself as Maplewood Family Medicine's "
-    "automated assistant and ask how you can help."
+GREETING_TEXT = (
+    "Hello, I'm Maplewood Family Medicine's automated demo assistant. "
+    "Please use only fake information here. How can I help?"
 )
 
 
@@ -101,14 +107,19 @@ class PatientIntakeAgent(Agent):
     """One conversational agent with a fixed, auditable clinic tool surface."""
 
     def __init__(self, clinic: Clinic, *, greet: bool = True) -> None:
-        super().__init__(instructions=BASE_INSTRUCTIONS)
+        timezone_name = clinic.now.tzname() or "local time"
+        current_time = (
+            f"The clinic's current date and time is "
+            f"{clinic.now:%A, %B %d, %Y at %I:%M %p} {timezone_name}."
+        )
+        super().__init__(instructions=f"{current_time}\n\n{BASE_INSTRUCTIONS}")
         self.clinic = clinic
         self.greet = greet
         self._new_patient_searches: set[tuple[str, date]] = set()
 
     async def on_enter(self) -> None:
         if self.greet:
-            self.session.generate_reply(instructions=GREETING_INSTRUCTIONS)
+            self.session.say(GREETING_TEXT)
 
     def _patient(self, last_name: str, date_of_birth: str) -> Patient:
         try:
@@ -130,7 +141,7 @@ class PatientIntakeAgent(Agent):
     @function_tool
     async def find_open_times(
         self,
-        patient_status: str,
+        patient_status: PatientStatus,
         last_name: str,
         date_of_birth: str,
         provider_id: str = "",
@@ -186,14 +197,14 @@ class PatientIntakeAgent(Agent):
     @function_tool
     async def book_appointment(
         self,
-        patient_status: str,
-        first_name: str,
+        patient_status: PatientStatus,
         last_name: str,
         date_of_birth: str,
-        phone: str,
         slot_id: str,
         visit_type: VisitType,
         reason: str,
+        first_name: str = "",
+        phone: str = "",
     ) -> str:
         """Book a time returned by find_open_times.
 
@@ -207,6 +218,8 @@ class PatientIntakeAgent(Agent):
             visit_type: new_problem, annual_physical, well_child, follow_up, or telehealth.
             reason: Brief caller-described reason without diagnosis.
         """
+        if patient_status not in {"new", "established"}:
+            raise ToolError("patient_status must be new or established.")
         born = _parse_date(date_of_birth, "date_of_birth")
         try:
             patient = self.clinic.find_patient(last_name, born)
@@ -220,24 +233,27 @@ class PatientIntakeAgent(Agent):
                     "Call find_open_times with these patient details before booking."
                 ) from None
             try:
-                patient = self.clinic.register_patient(
+                patient, appointment = self.clinic.register_and_book(
                     first_name=first_name,
                     last_name=last_name,
                     date_of_birth=born,
                     phone=phone,
+                    slot_id=slot_id,
+                    visit_type=visit_type,
+                    reason=reason,
                 )
             except ClinicError as error:
                 raise ToolError(str(error)) from error
-
-        try:
-            appointment = self.clinic.book(
-                patient=patient,
-                slot_id=slot_id,
-                visit_type=visit_type,
-                reason=reason,
-            )
-        except ClinicError as error:
-            raise ToolError(str(error)) from error
+        else:
+            try:
+                appointment = self.clinic.book(
+                    patient=patient,
+                    slot_id=slot_id,
+                    visit_type=visit_type,
+                    reason=reason,
+                )
+            except ClinicError as error:
+                raise ToolError(str(error)) from error
         provider = self.clinic.providers[appointment.provider_id]
         return f"Booked {_format_time(appointment.start)} with {provider.name}."
 
@@ -247,6 +263,7 @@ class PatientIntakeAgent(Agent):
         action: AppointmentAction,
         last_name: str,
         date_of_birth: str,
+        caller_relationship: CallerRelationship,
         appointment_id: str = "",
         new_slot_id: str = "",
     ) -> str:
@@ -256,10 +273,19 @@ class PatientIntakeAgent(Agent):
             action: list, cancel, or reschedule.
             last_name: Patient's surname.
             date_of_birth: Full date of birth in YYYY-MM-DD format.
+            caller_relationship: patient, parent_or_guardian, or other.
             appointment_id: Private appointment ID for cancel or reschedule.
             new_slot_id: Private slot ID from find_open_times for reschedule.
         """
         patient = self._patient(last_name, date_of_birth)
+        if caller_relationship == "other" or (
+            caller_relationship == "parent_or_guardian"
+            and patient.age_on(self.clinic.now.date()) >= 18
+        ):
+            return (
+                "Do not confirm whether an appointment exists. "
+                "The patient must contact the office directly."
+            )
         if action == "list":
             appointments = self.clinic.scheduled_appointments(patient)
             if not appointments:
@@ -390,6 +416,7 @@ def create_session(clinic: Clinic) -> AgentSession[CallState]:
     return AgentSession[CallState](
         userdata=CallState(clinic=clinic),
         llm=create_realtime_model(),
+        vad=None,
         max_tool_steps=8,
     )
 
@@ -399,7 +426,7 @@ server = AgentServer()
 
 @server.rtc_session(agent_name=AGENT_NAME)
 async def patient_intake(ctx: JobContext) -> None:
-    clinic = create_demo_clinic(datetime.now())
+    clinic = create_demo_clinic(datetime.now().astimezone())
     session = create_session(clinic)
     await session.start(
         agent=PatientIntakeAgent(clinic),

--- a/voice-agents/grok-patient-intake/src/agent.py
+++ b/voice-agents/grok-patient-intake/src/agent.py
@@ -216,7 +216,9 @@ class PatientIntakeAgent(Agent):
                     "No established patient matched those details. Check them before booking."
                 ) from None
             if (last_name.strip().casefold(), born) not in self._new_patient_searches:
-                raise ToolError("Call find_open_times with these patient details before booking.")
+                raise ToolError(
+                    "Call find_open_times with these patient details before booking."
+                ) from None
             try:
                 patient = self.clinic.register_patient(
                     first_name=first_name,

--- a/voice-agents/grok-patient-intake/src/clinic.py
+++ b/voice-agents/grok-patient-intake/src/clinic.py
@@ -206,6 +206,45 @@ class Clinic:
         self.appointments[appointment.id] = appointment
         return appointment
 
+    def register_and_book(
+        self,
+        *,
+        first_name: str,
+        last_name: str,
+        date_of_birth: date,
+        phone: str,
+        slot_id: str,
+        visit_type: VisitType,
+        reason: str,
+    ) -> tuple[Patient, Appointment]:
+        """Validate a new patient's booking before creating either record."""
+        if not first_name.strip() or not last_name.strip() or not phone.strip():
+            raise ClinicError("A new patient needs a first name, last name, and phone number.")
+        slot = self._available_slot(slot_id)
+        prospective_patient = Patient(
+            chart_id="pending",
+            first_name=first_name.strip(),
+            last_name=last_name.strip(),
+            date_of_birth=date_of_birth,
+            phone=phone.strip(),
+            registered_during_call=True,
+        )
+        self._ensure_eligible(prospective_patient, slot)
+
+        patient = self.register_patient(
+            first_name=first_name,
+            last_name=last_name,
+            date_of_birth=date_of_birth,
+            phone=phone,
+        )
+        appointment = self.book(
+            patient=patient,
+            slot_id=slot_id,
+            visit_type=visit_type,
+            reason=reason,
+        )
+        return patient, appointment
+
     def scheduled_appointments(self, patient: Patient) -> list[Appointment]:
         return sorted(
             (
@@ -401,7 +440,10 @@ def create_demo_clinic(now: datetime) -> Clinic:
         ),
     ]
     slots = [
-        Slot(provider_id=provider.id, start=datetime.combine(day, appointment_time))
+        Slot(
+            provider_id=provider.id,
+            start=datetime.combine(day, appointment_time, tzinfo=now.tzinfo),
+        )
         for day in _next_weekdays(now, 5)
         for provider in providers.values()
         for appointment_time in (time(9, 30), time(14, 0))

--- a/voice-agents/grok-patient-intake/src/clinic.py
+++ b/voice-agents/grok-patient-intake/src/clinic.py
@@ -328,9 +328,7 @@ class Clinic:
         except KeyError as error:
             raise ClinicError("That appointment time is no longer available.") from error
 
-    def _patient_appointment(
-        self, patient: Patient, appointment_id: str
-    ) -> Appointment:
+    def _patient_appointment(self, patient: Patient, appointment_id: str) -> Appointment:
         try:
             appointment = self.appointments[appointment_id]
         except KeyError as error:
@@ -341,9 +339,7 @@ class Clinic:
             raise ClinicError("That appointment is no longer scheduled.")
         return appointment
 
-    def _provider_can_see(
-        self, provider: Provider, patient: Patient, slot: Slot
-    ) -> bool:
+    def _provider_can_see(self, provider: Provider, patient: Patient, slot: Slot) -> bool:
         return provider.accepts(patient, slot.start) and (
             not patient.registered_during_call or provider.accepting_new_patients
         )
@@ -418,9 +414,7 @@ def create_demo_clinic(now: datetime) -> Clinic:
         _next_record_number=100,
     )
     existing_slot = next(
-        slot
-        for slot in clinic.open_slot_records.values()
-        if slot.provider_id == "rivera"
+        slot for slot in clinic.open_slot_records.values() if slot.provider_id == "rivera"
     )
     clinic.book(
         patient=patients[0],

--- a/voice-agents/grok-patient-intake/src/clinic.py
+++ b/voice-agents/grok-patient-intake/src/clinic.py
@@ -1,0 +1,431 @@
+"""Deterministic in-memory records for the patient-intake example."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from datetime import date, datetime, time, timedelta
+from typing import Literal
+
+VisitType = Literal[
+    "new_problem",
+    "annual_physical",
+    "well_child",
+    "follow_up",
+    "telehealth",
+]
+MessageKind = Literal[
+    "prescription_refill",
+    "test_results",
+    "billing",
+    "referral",
+    "medical_records",
+    "nurse_callback",
+]
+AppointmentAction = Literal["list", "cancel", "reschedule"]
+
+
+class ClinicError(ValueError):
+    """Raised when an in-memory clinic operation cannot be completed."""
+
+
+@dataclass(frozen=True, slots=True)
+class Provider:
+    id: str
+    name: str
+    sees_children: bool = False
+    sees_adults: bool = True
+    accepting_new_patients: bool = True
+
+    def accepts(self, patient: Patient, on_date: datetime) -> bool:
+        age = patient.age_on(on_date.date())
+        return (age < 18 and self.sees_children) or (age >= 18 and self.sees_adults)
+
+
+@dataclass(slots=True)
+class Insurance:
+    carrier: str
+    member_id: str
+    group_number: str = ""
+
+
+@dataclass(slots=True)
+class Patient:
+    chart_id: str
+    first_name: str
+    last_name: str
+    date_of_birth: date
+    phone: str
+    insurance: Insurance | None = None
+    registered_during_call: bool = False
+
+    def age_on(self, day: date) -> int:
+        return (
+            day.year
+            - self.date_of_birth.year
+            - ((day.month, day.day) < (self.date_of_birth.month, self.date_of_birth.day))
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class Slot:
+    provider_id: str
+    start: datetime
+
+    @property
+    def id(self) -> str:
+        value = f"{self.provider_id}:{self.start.isoformat()}".encode()
+        return f"SL-{hashlib.sha256(value).hexdigest()[:8].upper()}"
+
+
+@dataclass(slots=True)
+class Appointment:
+    id: str
+    chart_id: str
+    provider_id: str
+    start: datetime
+    visit_type: VisitType
+    reason: str
+    status: Literal["scheduled", "cancelled"] = "scheduled"
+
+    @property
+    def slot(self) -> Slot:
+        return Slot(provider_id=self.provider_id, start=self.start)
+
+
+@dataclass(frozen=True, slots=True)
+class Message:
+    id: str
+    chart_id: str
+    kind: MessageKind
+    summary: str
+    callback_phone: str
+
+
+@dataclass(slots=True)
+class IntakeRecord:
+    chart_id: str
+    chief_complaint: str
+    symptom_duration: str
+    medications: list[str]
+    allergies: list[str]
+    conditions: list[str]
+    pharmacy: str
+
+
+@dataclass(frozen=True, slots=True)
+class EmergencyEscalation:
+    symptoms: str
+    created_at: datetime
+
+
+@dataclass(slots=True)
+class Clinic:
+    """A fake family practice whose state lasts for one agent session."""
+
+    now: datetime
+    providers: dict[str, Provider]
+    patients: list[Patient]
+    open_slot_records: dict[str, Slot]
+    appointments: dict[str, Appointment] = field(default_factory=dict)
+    messages: list[Message] = field(default_factory=list)
+    intake_records: dict[str, IntakeRecord] = field(default_factory=dict)
+    emergency_escalations: list[EmergencyEscalation] = field(default_factory=list)
+    _next_record_number: int = 1
+
+    def find_patient(self, last_name: str, date_of_birth: date) -> Patient:
+        for patient in self.patients:
+            if (
+                patient.last_name.casefold() == last_name.strip().casefold()
+                and patient.date_of_birth == date_of_birth
+            ):
+                return patient
+        raise ClinicError("No patient matched that last name and date of birth.")
+
+    def register_patient(
+        self,
+        *,
+        first_name: str,
+        last_name: str,
+        date_of_birth: date,
+        phone: str,
+    ) -> Patient:
+        if not first_name.strip() or not last_name.strip() or not phone.strip():
+            raise ClinicError("A new patient needs a first name, last name, and phone number.")
+        patient = Patient(
+            chart_id=self._issue_id("MRN"),
+            first_name=first_name.strip(),
+            last_name=last_name.strip(),
+            date_of_birth=date_of_birth,
+            phone=phone.strip(),
+            registered_during_call=True,
+        )
+        self.patients.append(patient)
+        return patient
+
+    def open_slots(
+        self,
+        *,
+        patient: Patient,
+        provider_id: str | None = None,
+        preferred_date: date | None = None,
+    ) -> list[Slot]:
+        if provider_id and provider_id not in self.providers:
+            raise ClinicError(f"Unknown provider: {provider_id}.")
+        return sorted(
+            (
+                slot
+                for slot in self.open_slot_records.values()
+                if slot.start > self.now
+                and (provider_id is None or slot.provider_id == provider_id)
+                and (preferred_date is None or slot.start.date() == preferred_date)
+                and self._provider_can_see(self.providers[slot.provider_id], patient, slot)
+            ),
+            key=lambda slot: (slot.start, slot.provider_id),
+        )
+
+    def book(
+        self,
+        *,
+        patient: Patient,
+        slot_id: str,
+        visit_type: VisitType,
+        reason: str,
+    ) -> Appointment:
+        slot = self._available_slot(slot_id)
+        self._ensure_eligible(patient, slot)
+        appointment = Appointment(
+            id=self._issue_id("APT"),
+            chart_id=patient.chart_id,
+            provider_id=slot.provider_id,
+            start=slot.start,
+            visit_type=visit_type,
+            reason=reason.strip(),
+        )
+        self.open_slot_records.pop(slot_id)
+        self.appointments[appointment.id] = appointment
+        return appointment
+
+    def scheduled_appointments(self, patient: Patient) -> list[Appointment]:
+        return sorted(
+            (
+                appointment
+                for appointment in self.appointments.values()
+                if appointment.chart_id == patient.chart_id
+                and appointment.status == "scheduled"
+                and appointment.start > self.now
+            ),
+            key=lambda appointment: appointment.start,
+        )
+
+    def cancel(self, *, patient: Patient, appointment_id: str) -> Appointment:
+        appointment = self._patient_appointment(patient, appointment_id)
+        appointment.status = "cancelled"
+        self.open_slot_records[appointment.slot.id] = appointment.slot
+        return appointment
+
+    def reschedule(
+        self,
+        *,
+        patient: Patient,
+        appointment_id: str,
+        new_slot_id: str,
+    ) -> Appointment:
+        appointment = self._patient_appointment(patient, appointment_id)
+        new_slot = self._available_slot(new_slot_id)
+        self._ensure_eligible(patient, new_slot)
+        previous_slot = appointment.slot
+        self.open_slot_records.pop(new_slot_id)
+        self.open_slot_records[previous_slot.id] = previous_slot
+        appointment.provider_id = new_slot.provider_id
+        appointment.start = new_slot.start
+        return appointment
+
+    def update_insurance(
+        self,
+        *,
+        patient: Patient,
+        carrier: str,
+        member_id: str,
+        group_number: str,
+    ) -> Insurance:
+        if not carrier.strip() or not member_id.strip():
+            raise ClinicError("Carrier and member ID are required.")
+        patient.insurance = Insurance(
+            carrier=carrier.strip(),
+            member_id=member_id.strip(),
+            group_number=group_number.strip(),
+        )
+        return patient.insurance
+
+    def take_message(
+        self,
+        *,
+        patient: Patient,
+        kind: MessageKind,
+        summary: str,
+        callback_phone: str,
+    ) -> Message:
+        existing = next(
+            (
+                message
+                for message in self.messages
+                if message.chart_id == patient.chart_id and message.kind == kind
+            ),
+            None,
+        )
+        if existing is not None:
+            return existing
+        message = Message(
+            id=self._issue_id("MSG"),
+            chart_id=patient.chart_id,
+            kind=kind,
+            summary=summary.strip(),
+            callback_phone=callback_phone.strip() or patient.phone,
+        )
+        self.messages.append(message)
+        return message
+
+    def record_intake(
+        self,
+        *,
+        patient: Patient,
+        chief_complaint: str,
+        symptom_duration: str,
+        medications: list[str],
+        allergies: list[str],
+        conditions: list[str],
+        pharmacy: str,
+    ) -> IntakeRecord:
+        record = IntakeRecord(
+            chart_id=patient.chart_id,
+            chief_complaint=chief_complaint.strip(),
+            symptom_duration=symptom_duration.strip(),
+            medications=medications,
+            allergies=allergies,
+            conditions=conditions,
+            pharmacy=pharmacy.strip(),
+        )
+        self.intake_records[patient.chart_id] = record
+        return record
+
+    def record_emergency(self, symptoms: str) -> EmergencyEscalation:
+        escalation = EmergencyEscalation(
+            symptoms=symptoms.strip(),
+            created_at=self.now,
+        )
+        self.emergency_escalations.append(escalation)
+        return escalation
+
+    def _issue_id(self, prefix: str) -> str:
+        value = f"{prefix}-{self._next_record_number:04d}"
+        self._next_record_number += 1
+        return value
+
+    def _available_slot(self, slot_id: str) -> Slot:
+        try:
+            return self.open_slot_records[slot_id]
+        except KeyError as error:
+            raise ClinicError("That appointment time is no longer available.") from error
+
+    def _patient_appointment(
+        self, patient: Patient, appointment_id: str
+    ) -> Appointment:
+        try:
+            appointment = self.appointments[appointment_id]
+        except KeyError as error:
+            raise ClinicError("That appointment could not be found.") from error
+        if appointment.chart_id != patient.chart_id:
+            raise ClinicError("That appointment does not belong to this patient.")
+        if appointment.status != "scheduled":
+            raise ClinicError("That appointment is no longer scheduled.")
+        return appointment
+
+    def _provider_can_see(
+        self, provider: Provider, patient: Patient, slot: Slot
+    ) -> bool:
+        return provider.accepts(patient, slot.start) and (
+            not patient.registered_during_call or provider.accepting_new_patients
+        )
+
+    def _ensure_eligible(self, patient: Patient, slot: Slot) -> None:
+        provider = self.providers[slot.provider_id]
+        if not self._provider_can_see(provider, patient, slot):
+            raise ClinicError(f"{provider.name} cannot see this patient.")
+
+
+def _next_weekdays(now: datetime, count: int) -> list[date]:
+    days: list[date] = []
+    current = now.date()
+    while len(days) < count:
+        current += timedelta(days=1)
+        if current.weekday() < 5:
+            days.append(current)
+    return days
+
+
+def create_demo_clinic(now: datetime) -> Clinic:
+    """Create fresh fake records for a single call."""
+    providers = {
+        "rivera": Provider(
+            id="rivera",
+            name="Doctor Maya Rivera",
+            sees_children=False,
+            accepting_new_patients=True,
+        ),
+        "patel": Provider(
+            id="patel",
+            name="Doctor Nikhil Patel",
+            sees_children=False,
+            accepting_new_patients=False,
+        ),
+        "nguyen": Provider(
+            id="nguyen",
+            name="Doctor Linh Nguyen",
+            sees_children=True,
+            sees_adults=False,
+            accepting_new_patients=True,
+        ),
+    }
+    patients = [
+        Patient(
+            chart_id="MRN-DEMO-1",
+            first_name="Jamie",
+            last_name="Example",
+            date_of_birth=date(1987, 4, 12),
+            phone="555-0101",
+            insurance=Insurance(carrier="Example Health", member_id="DEMO-1001"),
+        ),
+        Patient(
+            chart_id="MRN-DEMO-2",
+            first_name="Riley",
+            last_name="Example",
+            date_of_birth=date(2018, 9, 3),
+            phone="555-0102",
+        ),
+    ]
+    slots = [
+        Slot(provider_id=provider.id, start=datetime.combine(day, appointment_time))
+        for day in _next_weekdays(now, 5)
+        for provider in providers.values()
+        for appointment_time in (time(9, 30), time(14, 0))
+    ]
+    clinic = Clinic(
+        now=now,
+        providers=providers,
+        patients=patients,
+        open_slot_records={slot.id: slot for slot in slots},
+        _next_record_number=100,
+    )
+    existing_slot = next(
+        slot
+        for slot in clinic.open_slot_records.values()
+        if slot.provider_id == "rivera"
+    )
+    clinic.book(
+        patient=patients[0],
+        slot_id=existing_slot.id,
+        visit_type="follow_up",
+        reason="demo follow-up",
+    )
+    return clinic

--- a/voice-agents/grok-patient-intake/tests/test_agent.py
+++ b/voice-agents/grok-patient-intake/tests/test_agent.py
@@ -1,0 +1,126 @@
+import ast
+from datetime import date, datetime
+from pathlib import Path
+
+import agent as agent_module
+from agent import (
+    DEFAULT_VOICE,
+    DEFAULT_VOICE_MODEL,
+    PatientIntakeAgent,
+    create_realtime_model,
+)
+from clinic import create_demo_clinic
+
+NOW = datetime(2026, 9, 2, 9, 0)
+
+
+def test_agent_exposes_the_eight_patient_intake_tools() -> None:
+    intake_agent = PatientIntakeAgent(create_demo_clinic(NOW), greet=False)
+
+    assert {tool.info.name for tool in intake_agent.tools} == {
+        "book_appointment",
+        "find_open_times",
+        "manage_appointment",
+        "read_practice_information",
+        "record_emergency_escalation",
+        "record_previsit_intake",
+        "take_message",
+        "update_insurance",
+    }
+
+
+def test_session_uses_one_realtime_model_without_cascade_components() -> None:
+    tree = ast.parse(Path("src/agent.py").read_text(encoding="utf-8"))
+    session_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Subscript)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "AgentSession"
+    ]
+
+    assert len(session_calls) == 1
+    keywords = {keyword.arg for keyword in session_calls[0].keywords}
+    assert "llm" in keywords
+    assert keywords.isdisjoint({"stt", "tts", "vad", "turn_detection"})
+
+
+def test_realtime_model_defaults_and_environment_overrides(monkeypatch) -> None:
+    calls: list[dict[str, str]] = []
+
+    def fake_realtime_model(**kwargs):
+        calls.append(kwargs)
+        return kwargs
+
+    monkeypatch.setattr(agent_module.xai.realtime, "RealtimeModel", fake_realtime_model)
+    monkeypatch.delenv("XAI_VOICE_MODEL", raising=False)
+    monkeypatch.delenv("XAI_VOICE", raising=False)
+
+    assert create_realtime_model() == {
+        "model": DEFAULT_VOICE_MODEL,
+        "voice": DEFAULT_VOICE,
+    }
+
+    monkeypatch.setenv("XAI_VOICE_MODEL", "future-voice-model")
+    monkeypatch.setenv("XAI_VOICE", "Eve")
+    assert create_realtime_model() == {
+        "model": "future-voice-model",
+        "voice": "Eve",
+    }
+    assert len(calls) == 2
+
+
+async def test_new_patient_search_and_booking_use_the_same_identity() -> None:
+    clinic = create_demo_clinic(NOW)
+    intake_agent = PatientIntakeAgent(clinic, greet=False)
+
+    openings = await intake_agent.find_open_times(
+        patient_status="new",
+        last_name="Demo",
+        date_of_birth="1990-01-01",
+    )
+    slot_id = next(
+        line.split(":", 1)[0]
+        for line in openings.splitlines()
+        if line.startswith("SL-")
+    )
+    result = await intake_agent.book_appointment(
+        patient_status="new",
+        first_name="Taylor",
+        last_name="Demo",
+        date_of_birth="1990-01-01",
+        phone="555-0199",
+        slot_id=slot_id,
+        visit_type="new_problem",
+        reason="demo concern",
+    )
+
+    patient = clinic.find_patient("Demo", date(1990, 1, 1))
+    assert patient.registered_during_call
+    assert clinic.scheduled_appointments(patient)
+    assert result.startswith("Booked ")
+
+
+async def test_intake_and_emergency_tools_write_durable_call_state() -> None:
+    clinic = create_demo_clinic(NOW)
+    intake_agent = PatientIntakeAgent(clinic, greet=False)
+
+    await intake_agent.record_previsit_intake(
+        last_name="Example",
+        date_of_birth="1987-04-12",
+        chief_complaint="demo concern",
+        symptom_duration="one week",
+        medications=[],
+        allergies=[],
+        conditions=[],
+        pharmacy="Demo Pharmacy",
+    )
+    emergency_result = await intake_agent.record_emergency_escalation(
+        reported_symptoms="demo emergency",
+    )
+
+    patient = clinic.find_patient("Example", date(1987, 4, 12))
+    assert patient.chart_id in clinic.intake_records
+    assert clinic.emergency_escalations
+    assert "Give the appropriate direction" in emergency_result

--- a/voice-agents/grok-patient-intake/tests/test_agent.py
+++ b/voice-agents/grok-patient-intake/tests/test_agent.py
@@ -44,10 +44,19 @@ def test_session_uses_one_realtime_model_without_cascade_components() -> None:
     assert len(session_calls) == 1
     keywords = {keyword.arg for keyword in session_calls[0].keywords}
     assert "llm" in keywords
-    assert keywords.isdisjoint({"stt", "tts", "turn_detection"})
+    assert keywords.isdisjoint({"stt", "tts"})
     vad_keyword = next(keyword for keyword in session_calls[0].keywords if keyword.arg == "vad")
     assert isinstance(vad_keyword.value, ast.Constant)
     assert vad_keyword.value.value is None
+    turn_handling = next(
+        keyword for keyword in session_calls[0].keywords if keyword.arg == "turn_handling"
+    )
+    assert isinstance(turn_handling.value, ast.Call)
+    realtime_turn_detection = next(
+        keyword for keyword in turn_handling.value.keywords if keyword.arg == "turn_detection"
+    )
+    assert isinstance(realtime_turn_detection.value, ast.Constant)
+    assert realtime_turn_detection.value.value == "realtime_llm"
 
 
 def test_realtime_model_defaults_and_environment_overrides(monkeypatch) -> None:

--- a/voice-agents/grok-patient-intake/tests/test_agent.py
+++ b/voice-agents/grok-patient-intake/tests/test_agent.py
@@ -6,6 +6,7 @@ import agent as agent_module
 from agent import (
     DEFAULT_VOICE,
     DEFAULT_VOICE_MODEL,
+    GREETING_TEXT,
     PatientIntakeAgent,
     create_realtime_model,
 )
@@ -43,7 +44,10 @@ def test_session_uses_one_realtime_model_without_cascade_components() -> None:
     assert len(session_calls) == 1
     keywords = {keyword.arg for keyword in session_calls[0].keywords}
     assert "llm" in keywords
-    assert keywords.isdisjoint({"stt", "tts", "vad", "turn_detection"})
+    assert keywords.isdisjoint({"stt", "tts", "turn_detection"})
+    vad_keyword = next(keyword for keyword in session_calls[0].keywords if keyword.arg == "vad")
+    assert isinstance(vad_keyword.value, ast.Constant)
+    assert vad_keyword.value.value is None
 
 
 def test_realtime_model_defaults_and_environment_overrides(monkeypatch) -> None:
@@ -69,6 +73,13 @@ def test_realtime_model_defaults_and_environment_overrides(monkeypatch) -> None:
         "voice": "Eve",
     }
     assert len(calls) == 2
+
+
+def test_agent_instructions_include_call_time_and_fake_data_disclosure() -> None:
+    intake_agent = PatientIntakeAgent(create_demo_clinic(NOW), greet=False)
+
+    assert "Wednesday, September 02, 2026 at 09:00 AM" in intake_agent.instructions
+    assert "fake information" in GREETING_TEXT
 
 
 async def test_new_patient_search_and_booking_use_the_same_identity() -> None:
@@ -98,6 +109,20 @@ async def test_new_patient_search_and_booking_use_the_same_identity() -> None:
     assert patient.registered_during_call
     assert clinic.scheduled_appointments(patient)
     assert result.startswith("Booked ")
+
+
+async def test_unrelated_caller_cannot_access_appointment_details() -> None:
+    intake_agent = PatientIntakeAgent(create_demo_clinic(NOW), greet=False)
+
+    result = await intake_agent.manage_appointment(
+        action="list",
+        last_name="Example",
+        date_of_birth="1987-04-12",
+        caller_relationship="other",
+    )
+
+    assert "Do not confirm whether an appointment exists" in result
+    assert "APT-" not in result
 
 
 async def test_intake_and_emergency_tools_write_durable_call_state() -> None:

--- a/voice-agents/grok-patient-intake/tests/test_agent.py
+++ b/voice-agents/grok-patient-intake/tests/test_agent.py
@@ -81,9 +81,7 @@ async def test_new_patient_search_and_booking_use_the_same_identity() -> None:
         date_of_birth="1990-01-01",
     )
     slot_id = next(
-        line.split(":", 1)[0]
-        for line in openings.splitlines()
-        if line.startswith("SL-")
+        line.split(":", 1)[0] for line in openings.splitlines() if line.startswith("SL-")
     )
     result = await intake_agent.book_appointment(
         patient_status="new",

--- a/voice-agents/grok-patient-intake/tests/test_clinic.py
+++ b/voice-agents/grok-patient-intake/tests/test_clinic.py
@@ -59,6 +59,24 @@ def test_new_adult_patient_cannot_book_with_closed_or_pediatric_provider() -> No
         )
 
 
+def test_failed_new_patient_booking_does_not_leave_a_chart() -> None:
+    clinic = create_demo_clinic(NOW)
+    patient_count = len(clinic.patients)
+
+    with pytest.raises(ClinicError, match="no longer available"):
+        clinic.register_and_book(
+            first_name="Taylor",
+            last_name="Demo",
+            date_of_birth=date(1990, 1, 1),
+            phone="555-0199",
+            slot_id="SL-NOT-REAL",
+            visit_type="new_problem",
+            reason="demo concern",
+        )
+
+    assert len(clinic.patients) == patient_count
+
+
 def test_messages_are_deduplicated_by_patient_and_kind() -> None:
     clinic = create_demo_clinic(NOW)
     patient = clinic.find_patient("Example", date(1987, 4, 12))

--- a/voice-agents/grok-patient-intake/tests/test_clinic.py
+++ b/voice-agents/grok-patient-intake/tests/test_clinic.py
@@ -1,0 +1,107 @@
+from datetime import date, datetime
+
+import pytest
+
+from clinic import ClinicError, create_demo_clinic
+
+NOW = datetime(2026, 9, 2, 9, 0)
+
+
+def test_demo_clinic_is_fresh_and_uses_only_fake_records() -> None:
+    first = create_demo_clinic(NOW)
+    second = create_demo_clinic(NOW)
+    first.patients[0].first_name = "Changed"
+
+    assert second.patients[0].first_name == "Jamie"
+    assert all("DEMO" in patient.chart_id for patient in second.patients)
+    assert second.open_slot_records
+
+
+def test_booking_rescheduling_and_cancellation_move_real_slots() -> None:
+    clinic = create_demo_clinic(NOW)
+    patient = clinic.find_patient("Example", date(1987, 4, 12))
+    original_appointment = clinic.scheduled_appointments(patient)[0]
+    destination = clinic.open_slots(patient=patient)[0]
+
+    clinic.reschedule(
+        patient=patient,
+        appointment_id=original_appointment.id,
+        new_slot_id=destination.id,
+    )
+    assert original_appointment.slot == destination
+
+    clinic.cancel(patient=patient, appointment_id=original_appointment.id)
+    assert original_appointment.status == "cancelled"
+    assert destination in clinic.open_slot_records.values()
+
+
+def test_new_adult_patient_cannot_book_with_closed_or_pediatric_provider() -> None:
+    clinic = create_demo_clinic(NOW)
+    patient = clinic.register_patient(
+        first_name="Taylor",
+        last_name="Demo",
+        date_of_birth=date(1990, 1, 1),
+        phone="555-0199",
+    )
+
+    available = clinic.open_slots(patient=patient)
+    assert {slot.provider_id for slot in available} == {"rivera"}
+
+    closed_slot = next(
+        slot for slot in clinic.open_slot_records.values() if slot.provider_id == "patel"
+    )
+    with pytest.raises(ClinicError, match="cannot see"):
+        clinic.book(
+            patient=patient,
+            slot_id=closed_slot.id,
+            visit_type="new_problem",
+            reason="demo concern",
+        )
+
+
+def test_messages_are_deduplicated_by_patient_and_kind() -> None:
+    clinic = create_demo_clinic(NOW)
+    patient = clinic.find_patient("Example", date(1987, 4, 12))
+
+    first = clinic.take_message(
+        patient=patient,
+        kind="prescription_refill",
+        summary="Demo refill",
+        callback_phone="",
+    )
+    second = clinic.take_message(
+        patient=patient,
+        kind="prescription_refill",
+        summary="Duplicate demo refill",
+        callback_phone="",
+    )
+
+    assert first is second
+    assert len(clinic.messages) == 1
+    assert first.callback_phone == patient.phone
+
+
+def test_insurance_intake_and_emergency_records_are_mutated_in_memory() -> None:
+    clinic = create_demo_clinic(NOW)
+    patient = clinic.find_patient("Example", date(1987, 4, 12))
+
+    clinic.update_insurance(
+        patient=patient,
+        carrier="Demo Health",
+        member_id="DEMO-2002",
+        group_number="GROUP-DEMO",
+    )
+    intake = clinic.record_intake(
+        patient=patient,
+        chief_complaint="demo knee pain",
+        symptom_duration="two days",
+        medications=[],
+        allergies=[],
+        conditions=[],
+        pharmacy="Demo Pharmacy",
+    )
+    escalation = clinic.record_emergency("demo emergency")
+
+    assert patient.insurance and patient.insurance.carrier == "Demo Health"
+    assert clinic.intake_records[patient.chart_id] is intake
+    assert clinic.emergency_escalations == [escalation]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a fictional family-medicine patient-intake agent inspired by LiveKit's xAI patient-intake demo
- use one `xai.realtime.RealtimeModel` (`grok-voice-latest`, voice `Ara`) for native speech-to-speech interaction instead of an STT → LLM → TTS cascade
- set `vad=None` and `TurnHandlingOptions(turn_detection="realtime_llm")` so xAI's server VAD explicitly owns speech turns
- provide eight typed tools for practice policy, appointment workflows, messages, insurance, pre-visit intake, and emergency escalation
- include deterministic fake clinic records, new-patient atomicity, appointment privacy guards, current clinic time context, and a spoken fake-data disclosure
- document console and LiveKit Agents Playground usage, provider data handling, floating model aliases, endpointing considerations, and production medical/privacy limitations

This focused cookbook port uses the LiveKit console or Agents Playground rather than copying the upstream custom Next.js frontend.

## Testing
- clean editable install with `livekit-agents==1.7.1` and `livekit-plugins-xai==1.7.1`
- `pytest -v` (13 offline tests pass)
- `ruff check .`
- `ruff format --check .`
- `python -m compileall -q src tests`
- `python src/agent.py --help`
- instantiated the real xAI realtime model and inspected the LiveKit `AgentSession`: `stt=None`, `tts=None`, `vad=None`, `turn_detection=realtime_llm`
- no API request or credits used
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d2113cb-b6f3-4fe0-b78d-eb6adceb505f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d2113cb-b6f3-4fe0-b78d-eb6adceb505f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

